### PR TITLE
Set TOKENIZERS_PARALLELISM if not set

### DIFF
--- a/utils/pruning.py
+++ b/utils/pruning.py
@@ -1,3 +1,4 @@
+import os
 from typing import Dict, List, Tuple
 from sentence_transformers import SentenceTransformer
 import spacy
@@ -5,6 +6,8 @@ import pickle
 import torch
 import torch.nn.functional as F
 
+if os.getenv("TOKENIZERS_PARALLELISM") is None:
+    os.environ["TOKENIZERS_PARALLELISM"] = "false"
 encoder = SentenceTransformer("sentence-transformers/all-MiniLM-L6-v2")
 nlp = spacy.load("en_core_web_sm")
 


### PR DESCRIPTION
Previously, we used to get a warning about tokenizers_parallelism not being set. Eg:
```
$ python main.py \
  -q data/questions_gen.csv \
  -o results/my_query_generator.csv \
  -g oa \
  -f prompts/prompt.md \
  -m gpt-3.5-turbo-0613 \
  -n 1 \
  -p 5 \
  -v
preparing questions...
  0%|                                                                                                                                                                  | 0/1 [00:00<?, ?it/s]huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...
To disable this warning, you can either:
	- Avoid using `tokenizers` before the fork if possible
	- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)
huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...
To disable this warning, you can either:
	- Avoid using `tokenizers` before the fork if possible
	- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)
Correct so far: 0/1 (0.00%): 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:02<00:00,  2.47s/it]
Average rate of exact match: 0.00
Average correct rate: 0.00
```
We now set it if it's not present in the environment.
Tested locally (without the env variable set) and the warning no longer shows up:
```
$ python main.py \
  -q data/questions_gen.csv \
  -o results/my_query_generator.csv \
  -g oa \
  -f prompts/prompt.md \
  -m gpt-3.5-turbo-0613 \
  -n 5 \
  -p 5 \
  -v
preparing questions...
Correct so far: 3/5 (60.00%): 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 5/5 [00:02<00:00,  1.92it/s]
Average rate of exact match: 0.60
Average correct rate: 0.60
```