### PR TITLE
Updated documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,13 +19,15 @@ echo -e '#!/bin/sh\n#\n# Run linter before commit\nblack $(git rev-parse --show-
 
 [_Quis probabit ipsa probationem?_](https://en.wikipedia.org/wiki/Quis_custodiet_ipsos_custodes%3F)
 
-We have a comprehensive test suite that ensures the quality and reliability of our codebase. To run the tests, you can use the following command:
+We have a comprehensive test suite that ensures the quality and reliability of our codebase. To run the python tests, you can use the following command:
 
 ```bash
 pytest tests
 ```
 
 Please make sure that all tests pass before submitting your changes.
+
+We also understand that some changes might not be easily testable with unit tests, for example, modifications of the underlying data schema, like column descriptions. In such cases, please provide a detailed description of your changes and how you tested them. We will review your changes and work with you to ensure that they are tested and verified.
 
 ## Submitting Changes
 
@@ -36,5 +38,9 @@ When submitting changes to this repository, please follow these steps:
 - Run the tests to ensure your changes don't introduce any regressions.
 - Lint your code and [squash your commits](https://www.git-tower.com/learn/git/faq/git-squash) down to 1 single commit.
 - Commit your changes and push them to your forked repository.
-- Open a pull request to the main repository and provide a detailed description of your changes.
+- Open a pull request to the main repository and provide a detailed description of your changes:
+  - What problem you are trying to solve.
+  - Alternatives considered and how you decided on which one to take
+  - How you solved it.
+  - How you tested your changes.
 - Your pull request will be reviewed by our team, and we may ask for further improvements or clarifications before merging. Thank you for your contribution!

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The data for importing is already in the exported SQL dumps in the `data/export`
 
 ### Query Generator
 
-To test your own query generator with our framework, you would need to extend `QueryGenerator` and implement the `generate_query` method to return the query of interest. We create a new class for each question/query pair to isolate each pair's runtime state against the others when running concurrently. You can see the sample `OpenAIQueryGenerator` in `query_generators/openai.py` which implements the class and uses a simple prompt to send a message over to OpenAI's API. Feel free to extend it for your own use. 
+To test your own query generator with our framework, you would need to extend [Query Generator](query_generators/query_generator.py) and implement the [generate_query](query_generators/query_generator.py#L18) method to return the query of interest. We create a new class for each question/query pair to isolate each pair's runtime state against the others when running concurrently. You can also reference [OpenAIQueryGenerator](query_generators/openai.py) which implements `Query Generator` and uses a simple prompt to send a message over to OpenAI's API. Feel free to extend it for your own use.
 
 If there are functions that are generally useful for all query generators, they can be placed in the `utils` folder. If you need to incorporate specific verbose templates (e.g. for prompt testing), you can store them in the `prompts` folder, and later import them. Being able to version control the prompts in a central place has been a productivity win for our team.
 
@@ -76,7 +76,7 @@ Having implemented the query generator, the next piece of abstraction would be t
 
 ### OpenAI
 Remember to have your OpenAI API key (`OPENAI_API_KEY="sk-..."`) set as an environment variable before running the test. Instructions [here](https://help.openai.com/en/articles/5112595-best-practices-for-api-key-safety). <br> 
-To test it out with just 1 question (instead of all 175):
+To test it out with just 10 questions (instead of all 175):
 
 ```bash
 mkdir results # create directory for storing results
@@ -86,13 +86,12 @@ python main.py \
   -g oa \
   -f prompts/prompt.md \
   -m gpt-3.5-turbo-0613 \
-  -n 1 \
-  -p 1 \
-  -v
+  -n 10 \
+  -p 5
 ```
 
 ### Hugging Face
-To test it out with just 10 questions (instead of all 175):
+To test it out with our fine-tuned sql model with just 10 questions (instead of all 175):
 
 ```bash
 mkdir results #create directory for storing results
@@ -131,6 +130,7 @@ We welcome contributions to our project, specifically:
 - Dataset
   - Adding new database schema/data
 - Framework code
-  - New query generators/runners
+  - New query generators/runners (in the [query_generators](query_generators) and [eval](eval) folders respectively)
   - Improving existing generators/runners (e.g. adding new metrics)
+
 Please see [CONTRIBUTING.md](https://github.com/defog-ai/sql-generation-evaluation/blob/main/CONTRIBUTING.md) for more information.

--- a/main.py
+++ b/main.py
@@ -8,8 +8,8 @@ if __name__ == "__main__":
     parser.add_argument("-q", "--questions_file", type=str, required=True)
     parser.add_argument("-o", "--output_file", type=str, required=True)
     parser.add_argument("-g", "--model_type", type=str, required=True)
+    parser.add_argument("-m", "--model", type=str)
     parser.add_argument("-f", "--prompt_file", type=str, required=True)
-    parser.add_argument("-m", "--model", type=str, default="gpt-3.5-turbo-0613")
     parser.add_argument("-n", "--num_questions", type=int, default=None)
     parser.add_argument("-p", "--parallel_threads", type=int, default=5)
     parser.add_argument("-t", "--timeout_gen", type=float, default=30.0)
@@ -19,6 +19,8 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     if args.model_type == "oa":
+        if args.model is None:
+            args.model = "gpt-3.5-turbo-0613"
         run_openai_eval(args)
     elif args.model_type == "hf":
         run_hf_eval(

--- a/main.py
+++ b/main.py
@@ -23,6 +23,10 @@ if __name__ == "__main__":
             args.model = "gpt-3.5-turbo-0613"
         run_openai_eval(args)
     elif args.model_type == "hf":
+        if args.model is None:
+            raise ValueError(
+                "Model must be specified for HF model type. See section on CLI flags in README.md for more details."
+            )
         run_hf_eval(
             questions_file=args.questions_file,
             prompt_file=args.prompt_file,


### PR DESCRIPTION
updated README.md and CONTRIBUTING.md with relative links to code in repo.
updated runner to only set default model for `oa` instead of all model_type's to avoid silent failures where `hf` uses the default model when unspecified. now the error should appear up front in the args when it isn't set when using `hf`, which is a lot less verbose and clearer:
```
$ python -W ignore main.py \
  -q data/questions_gen.csv \
  -o results/results.csv \
  -g hf \
  -f prompts/prompt.md
Traceback (most recent call last):
  File "/Users/jp/workspace/sql-eval/main.py", line 27, in <module>
    raise ValueError(
ValueError: Model must be specified for HF model type. See section on CLI flags in README.md for more details.
```