### PR TITLE
Main fix: updating the `get_all_minimal_queries` function to avoid errors

### DIFF
--- a/eval/eval.py
+++ b/eval/eval.py
@@ -8,7 +8,7 @@ from pandas.testing import assert_frame_equal, assert_series_equal
 from sqlalchemy import create_engine
 
 # like_pattern = r"LIKE\s+'[^']*'"
-like_pattern = r"LIKE[\s\S]*'"
+LIKE_PATTERN = r"LIKE[\s\S]*'"
 
 
 def normalize_table(
@@ -62,6 +62,9 @@ def find_bracket_indices(s: str, start_index: int = 0) -> "tuple[int, int]":
 
 # extrapolate all possible queries from a query with { } in it
 def get_all_minimal_queries(query: str) -> "list[str]":
+    query = " ".join(
+        query.split()
+    )  # replace multiple whitespaces with single space to avoid errors
     start, end = find_bracket_indices(query, 0)
     if (start, end) == (-1, -1):
         return [query]
@@ -92,7 +95,7 @@ def query_postgres_db(
     """
     Runs query on postgres db and returns results as a dataframe.
     This assumes that you have the evaluation database running locally.
-    If you don't, you can following the instructions in the README (Start Postgres Instance) to set it up.
+    If you don't, you can following the instructions in the README (Restoring to Postgres) to set it up.
 
     timeout: time in seconds to wait for query to finish before timing out
     """
@@ -108,7 +111,7 @@ def query_postgres_db(
         db_url = f"postgresql://{db_creds['user']}:{db_creds['password']}@{db_creds['host']}:{db_creds['port']}/{db_name}"
         engine = create_engine(db_url)
         escaped_query = re.sub(
-            like_pattern, escape_percent, query, flags=re.IGNORECASE
+            LIKE_PATTERN, escape_percent, query, flags=re.IGNORECASE
         )  # ignore case of LIKE
         results_df = func_timeout(
             timeout, pd.read_sql_query, args=(escaped_query, engine)

--- a/eval/hf_runner.py
+++ b/eval/hf_runner.py
@@ -1,7 +1,13 @@
 from eval.eval import compare_query_results
 import pandas as pd
 import torch
-from transformers import AutoTokenizer, AutoModelForCausalLM, pipeline
+from transformers import (
+    AutoTokenizer,
+    AutoModelForCausalLM,
+    LlamaTokenizer,
+    LlamaForCausalLM,
+    pipeline,
+)
 from utils.pruning import prune_metadata_str
 from utils.questions import prepare_questions_df
 from tqdm import tqdm
@@ -22,14 +28,25 @@ def generate_prompt(prompt_file, question, db_name):
 
 
 def get_tokenizer_model(model_name):
-    tokenizer = AutoTokenizer.from_pretrained(model_name)
-    model = AutoModelForCausalLM.from_pretrained(
-        model_name,
-        trust_remote_code=True,
-        torch_dtype=torch.float16,
-        device_map="auto",
-        use_cache=True,
-    )
+    if "llama" not in model_name:
+        tokenizer = AutoTokenizer.from_pretrained(model_name)
+        model = AutoModelForCausalLM.from_pretrained(
+            model_name,
+            trust_remote_code=True,
+            torch_dtype=torch.float16,
+            device_map="auto",
+            use_cache=True,
+        )
+    else:
+        tokenizer = LlamaTokenizer.from_pretrained(
+            model_name, legacy=False, use_fast=True
+        )
+        model = LlamaForCausalLM.from_pretrained(
+            model_name,
+            torch_dtype=torch.float16,
+            device_map="auto",
+            use_cache=True,
+        )
     return tokenizer, model
 
 
@@ -53,6 +70,7 @@ def run_hf_eval(
     print("questions prepared\nnow loading model...")
     # initialize tokenizer and model
     tokenizer, model = get_tokenizer_model(model_name)
+    model.tie_weights()
 
     print("model loaded\nnow generating and evaluating predictions...")
 
@@ -64,11 +82,18 @@ def run_hf_eval(
     total_correct = 0
     output_rows = []
 
-    pipeline_config = {
-        "max_new_tokens": 300,
-        "do_sample": False,
-        "num_beams": 5,
-    }
+    if "llama" not in model_name.lower():
+        pipeline_config = {
+            "max_new_tokens": 300,
+            "do_sample": False,
+            "num_beams": 5,
+        }
+    else:
+        pipeline_config = {
+            "max_new_tokens": 300,
+            "do_sample": False,
+            "num_beams": 3,
+        }
 
     with tqdm(total=len(df)) as pbar:
         for row in df.to_dict("records"):


### PR DESCRIPTION
This PR does 2 main things

**1. Fixing the `GROUP BY {}` bug that was affecting all queries**
Our `get_all_minimal_queries` function that dynamically updates `GROUP BY` statements currently expects a single space between the `GROUP BY` and curly braces (`{}`)

```python
if right.find("GROUP BY {}"):
    right = right.replace("GROUP BY {}", f"GROUP BY {column_str}")
```

However, if a query has something like `GROUP BY    {}`, this will not replace the query.

With this in view, we now reformat the query at the beginning of a function like this:

```python
query = " ".join(
    query.split()
)  # replace multiple whitespaces with single space to avoid errors
```

**2. Adding better support for Llama-2 based models**
We now use the `LlamaForCausalLM` and `LlamaTokenizer` classes instead of `AutoModelForCausalLM` and `AutoTokenizer` to load Llama models for runtime efficiency.