### PR TITLE
This commit fixes #32

### DIFF
--- a/utils/pruning.py
+++ b/utils/pruning.py
@@ -22,7 +22,7 @@ def knn(
     """
     Get top most similar columns' embeddings to query using cosine similarity.
     """
-    query_emb = encoder.encode(query, convert_to_tensor=True, device="cpu")
+    query_emb = encoder.encode(query, convert_to_tensor=True, device="cpu").unsqueeze(0)
     similarity_scores = F.cosine_similarity(query_emb, all_emb)
     top_results = torch.nonzero(similarity_scores > threshold).squeeze()
     # if top_results is empty, return empty tensors


### PR DESCRIPTION
The problem is that the query_emb was of shape 384 previously, and we need to add an additional dimension to it to make it (1, 384). This requirement came into being in torch 2.1 (backwards compatible with torch 2.0 also).