### PR TITLE
 Add support for private data

### DIFF
--- a/eval/hf_runner.py
+++ b/eval/hf_runner.py
@@ -17,11 +17,11 @@ import gc
 from peft import PeftModel, PeftConfig
 
 
-def generate_prompt(prompt_file, question, db_name):
+def generate_prompt(prompt_file, question, db_name, public_data):
     with open(prompt_file, "r") as f:
         prompt = f.read()
 
-    pruned_metadata_str = prune_metadata_str(question, db_name)
+    pruned_metadata_str = prune_metadata_str(question, db_name, public_data)
     prompt = prompt.format(
         user_question=question, table_metadata_string=pruned_metadata_str
     )
@@ -68,6 +68,7 @@ def run_hf_eval(
     questions_file: str,
     prompt_file: str,
     num_questions: int = None,
+    public_data: bool = True,
     model_name: str = "defog/starcoder-finetune-v3",
     output_file: str = "results.csv",
 ):
@@ -77,7 +78,9 @@ def run_hf_eval(
 
     # create a prompt for each question
     df["prompt"] = df[["question", "db_name"]].apply(
-        lambda row: generate_prompt(prompt_file, row["question"], row["db_name"]),
+        lambda row: generate_prompt(
+            prompt_file, row["question"], row["db_name"], public_data
+        ),
         axis=1,
     )
 

--- a/main.py
+++ b/main.py
@@ -6,11 +6,12 @@ import argparse
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("-q", "--questions_file", type=str, required=True)
-    parser.add_argument("-o", "--output_file", type=str, required=True)
+    parser.add_argument("-n", "--num_questions", type=int, default=None)
     parser.add_argument("-g", "--model_type", type=str, required=True)
     parser.add_argument("-m", "--model", type=str)
     parser.add_argument("-f", "--prompt_file", type=str, required=True)
-    parser.add_argument("-n", "--num_questions", type=int, default=None)
+    parser.add_argument("-d", "--use_defog_data", type=bool, default=True)
+    parser.add_argument("-o", "--output_file", type=str, required=True)
     parser.add_argument("-p", "--parallel_threads", type=int, default=5)
     parser.add_argument("-t", "--timeout_gen", type=float, default=30.0)
     parser.add_argument("-u", "--timeout_exec", type=float, default=10.0)
@@ -35,6 +36,7 @@ if __name__ == "__main__":
             questions_file=args.questions_file,
             prompt_file=args.prompt_file,
             num_questions=args.num_questions,
+            public_data=args.use_defog_data,
             model_name=args.model,
             output_file=args.output_file,
         )

--- a/utils/pruning.py
+++ b/utils/pruning.py
@@ -1,4 +1,3 @@
-import defog_data.supplementary as sup
 import os
 from typing import Dict, List, Tuple
 from sentence_transformers import SentenceTransformer
@@ -163,10 +162,14 @@ def get_md_emb(
     return md_str
 
 
-def prune_metadata_str(question, db_name):
+def prune_metadata_str(question, db_name, public_data=True):
     # current file dir
     root_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
     emb_path = os.path.join(root_dir, "data", "embeddings.pkl")
+    if public_data:
+        import defog_data.supplementary as sup
+    else:
+        import defog_data_private.supplementary as sup
     emb, csv_descriptions = sup.load_embeddings(emb_path)
     table_metadata_csv = get_md_emb(
         question,


### PR DESCRIPTION
- We now allow users to pass in a boolean flag from the cli args down through to prune_metadata_str to allow the selection of a private data library for evaluations. The flag defaults to True, which means defog-data is used by default.
- Added instructions for how to incorporate private data.