### PR TITLE
Various Fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 data/postgres
 data/embeddings.pkl
+results
 
 # pycache
 **/__pycache__/

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ You can use the following flags in the command line to change the configurations
 |  -g, --model_type   |  Model type used. Make sure this matches the model used. Currently defined options in `main.py` are `oa` for OpenAI models and `hf` for Hugging Face models.   |
 |  -m, --model   |  Model that will be tested and used to generate the queries. Currently defined options for OpenAI models are chat models `gpt-3.5-turbo-0613` and `gpt-4-0613`, and non-chat model `text-davinci-003`. For Hugging Face models, simply use the path of your chosen model (e.g. `defog/sqlcoder`).  |
 |  -f, --prompt_file   |  Markdown file with the prompt used for query generation.  |
-|  -d, --use_defog_data  |  Use this to toggle between using the public data or your own private data.  |
+|  -d, --use_private_data  |  Use this to read from your own private data library.  |
 |  -o, --output_file   |  Output CSV file that will store your results.   |
 | -p, --parallel_threads  |  The default no. of parallel threads is 5. Decrease this to 1 for gpt-4 to avoid the rate limit error. Parallelization support is currently only defined for OpenAI models.  |
 | -t, --timeout_gen  |  No. of seconds before timeout occurs for query generation. The default is 30.0s. |

--- a/eval/openai_runner.py
+++ b/eval/openai_runner.py
@@ -12,21 +12,6 @@ def run_openai_eval(args):
     print("preparing questions...")
     # get questions
     question_query_df = prepare_questions_df(args.questions_file, args.num_questions)
-    qg_class = OpenAIQueryGenerator
-    # add columns for generated query and metrics
-    question_query_df["generated_query"] = ""
-    question_query_df["reason"] = ""
-    question_query_df["error_msg"] = ""
-    question_query_df["exact_match"] = 0
-    question_query_df["correct"] = 0
-    question_query_df["error_query_gen"] = 0
-    question_query_df["error_db_exec"] = 0
-    question_query_df["timeout"] = 0
-    # add custom metrics below:
-    question_query_df["latency_seconds"] = 0.0  # latency of query generation in seconds
-    question_query_df["tokens_used"] = 0  # number of tokens used in query generation
-
-    question_query_df.reset_index(inplace=True, drop=True)
 
     input_rows = question_query_df.to_dict("records")
     output_rows = []
@@ -44,11 +29,12 @@ def run_openai_eval(args):
                 "database": db_name,
             }
 
-            qg = qg_class(
+            qg = OpenAIQueryGenerator(
                 db_creds=copy.deepcopy(db_creds),
                 model=args.model,
                 prompt_file=args.prompt_file,
                 timeout=args.timeout_gen,
+                use_public_data=not args.use_private_data,
                 verbose=args.verbose,
             )
 

--- a/main.py
+++ b/main.py
@@ -9,8 +9,9 @@ if __name__ == "__main__":
     parser.add_argument("-n", "--num_questions", type=int, default=None)
     parser.add_argument("-g", "--model_type", type=str, required=True)
     parser.add_argument("-m", "--model", type=str)
+    parser.add_argument("-a", "--adapter", type=str)
     parser.add_argument("-f", "--prompt_file", type=str, required=True)
-    parser.add_argument("-d", "--use_defog_data", type=bool, default=True)
+    parser.add_argument("-d", "--use_private_data", action="store_true")
     parser.add_argument("-o", "--output_file", type=str, required=True)
     parser.add_argument("-p", "--parallel_threads", type=int, default=5)
     parser.add_argument("-t", "--timeout_gen", type=float, default=30.0)
@@ -28,18 +29,7 @@ if __name__ == "__main__":
             args.model = "claude-2"
         run_anthropic_eval(args)
     elif args.model_type == "hf":
-        if args.model is None:
-            raise ValueError(
-                "Model must be specified for HF model type. See section on CLI flags in README.md for more details."
-            )
-        run_hf_eval(
-            questions_file=args.questions_file,
-            prompt_file=args.prompt_file,
-            num_questions=args.num_questions,
-            public_data=args.use_defog_data,
-            model_name=args.model,
-            output_file=args.output_file,
-        )
+        run_hf_eval(args)
     else:
         raise ValueError(
             f"Invalid model type: {args.model_type}. Model type must be one of: 'oa', 'hf'"

--- a/query_generators/openai.py
+++ b/query_generators/openai.py
@@ -20,6 +20,7 @@ class OpenAIQueryGenerator(QueryGenerator):
         model: str,
         prompt_file: str,
         timeout: int,
+        use_public_data: bool,
         verbose: bool,
         **kwargs,
     ):
@@ -27,6 +28,7 @@ class OpenAIQueryGenerator(QueryGenerator):
         self.db_name = db_creds["database"]
         self.model = model
         self.prompt_file = prompt_file
+        self.use_public_data = use_public_data
 
         self.timeout = timeout
         self.verbose = verbose
@@ -147,7 +149,9 @@ class OpenAIQueryGenerator(QueryGenerator):
 
             user_prompt = user_prompt.format(
                 user_question=question,
-                table_metadata_string=prune_metadata_str(question, self.db_name),
+                table_metadata_string=prune_metadata_str(
+                    question, self.db_name, self.use_public_data
+                ),
             )
 
             messages = []

--- a/utils/pruning.py
+++ b/utils/pruning.py
@@ -167,8 +167,10 @@ def prune_metadata_str(question, db_name, public_data=True):
     root_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
     emb_path = os.path.join(root_dir, "data", "embeddings.pkl")
     if public_data:
+        print("Loading public data")
         import defog_data.supplementary as sup
     else:
+        print("Loading private data")
         import defog_data_private.supplementary as sup
     emb, csv_descriptions = sup.load_embeddings(emb_path)
     table_metadata_csv = get_md_emb(

--- a/utils/questions.py
+++ b/utils/questions.py
@@ -1,7 +1,8 @@
+from typing import Optional
 import pandas as pd
 
 
-def prepare_questions_df(questions_file, num_questions):
+def prepare_questions_df(questions_file: str, num_questions: Optional[int] = None):
     question_query_df = pd.read_csv(questions_file, nrows=num_questions)
     question_query_df["generated_query"] = ""
     question_query_df["reason"] = ""


### PR DESCRIPTION
Managed to test and fixed a few edge cases
- we now pass args to `run_hf_eval` (standardize with other runners)
- we use `-d` as a boolean flag to opt in for private data. previous cli arg was faulty.
- fix openai runner to able to use private data
- update hf runner to use adapter if available

Verified that it runs with both openai and hf runners respectively:

**OA**
```
$ python main.py \
  -q data/private_questions.csv \
  -o results/private_questions.csv \
  -g oa \
  -d \
  -f prompts/prompt.md \
  -m gpt-3.5-turbo
/Users/jp/workspace/miniconda3/lib/python3.11/site-packages/bitsandbytes/cextension.py:34: UserWarning: The installed version of bitsandbytes was compiled without GPU support. 8-bit optimizers, 8-bit multiplication, and GPU quantization are unavailable.
  warn("The installed version of bitsandbytes was compiled without GPU support. "
'NoneType' object has no attribute 'cadam32bit_grad_fp32'
preparing questions...
Loading private data
  0%|                                                                | 0/1 [00:00<?, ?it/s]Loading embeddings from file /Users/jp/workspace/sql-eval/data/embeddings.pkl
Correct so far: 1/1 (100.00%): 100%|█████████████████████████| 1/1 [00:01<00:00,  1.58s/it]
                exact_match  correct
query_category
joins                   1.0      1.0
Average correct rate: 1.00
```

**HF** (We use starcodebase-1b)
```
$ python main.py \
  -q data/private_questions.csv \
  -o results/hf_private_results.csv \
  -g hf \
  -d \
  -f prompts/prompt.md \
  -m bigcode/starcoderbase-1b
preparing questions...
Using None questions from data/private_questions.csv
Loading private data
Embeddings file /home/defog/sql-eval/data/embeddings.pkl does not exist.
...
Saved embeddings to file /home/defog/sql-eval/data/embeddings.pkl
questions prepared
now loading model...
Loading model bigcode/starcoderbase-1b
model loaded
now generating and evaluating predictions...
Correct so far: 0/1 (0.00%): 100%|█████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:11<00:00, 11.82s/it]
                exact_match  correct
query_category                      
joins                   0.0      0.0
```