### PR TITLE
Dynamic Beams

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: psf/black@stable
   test:
     runs-on: ubuntu-latest
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: '3.11'
           cache: 'pip'
       - name: Install pip dependencies
         run: |

--- a/prompts/prompt.md
+++ b/prompts/prompt.md
@@ -1,15 +1,15 @@
-### Instructions:
-Your task is to convert a question into a SQL query, given a Postgres database schema.
-Adhere to these rules:
-- **Deliberately go through the question and database schema word by word** to appropriately answer the question
-- **Use Table Aliases** to prevent ambiguity. For example, `SELECT table1.col1, table2.col1 FROM table1 JOIN table2 ON table1.id = table2.id`.
-- When creating a ratio, always cast the numerator as float
+### Task
+Generate a SQL query to answer the following question:
+`{user_question}`
 
-### Input:
-Generate a SQL query that answers the question `{user_question}`.
-This query will run on a database whose schema is represented in this string:
+### Database Schema
+The query will run on a database with the following schema:
 {table_metadata_string}
 
-### Response:
-Based on your instructions, here is the SQL query I have generated to answer the question `{user_question}`:
+### SQL
+Follow these steps to create the SQL Query:
+1. Only use the columns and tables present in the database schema
+2. Use table aliases to prevent ambiguity when doing joins. For example, `SELECT table1.col1, table2.col1 FROM table1 JOIN table2 ON table1.id = table2.id`.
+
+Given the database schema, here is the SQL query that answers `{user_question}`:
 ```sql

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,13 +5,14 @@ defog-data==0.1.1
 func_timeout
 openai
 pandas
+peft
 psycopg2-binary
 pytest
+pyyaml
+sentence-transformers
 spacy
 sqlalchemy
 tiktoken
-pyyaml
-sentence-transformers
 torch
 tqdm
 transformers

--- a/tests/test_hf_runner.py
+++ b/tests/test_hf_runner.py
@@ -1,0 +1,22 @@
+import pytest
+from transformers import AutoTokenizer
+
+from eval.hf_runner import dynamic_num_beams
+
+
+@pytest.fixture
+def tokenizer():
+    return AutoTokenizer.from_pretrained("gpt2")
+
+
+def test_dynamic_num_beams_ranges(tokenizer):
+    prompt = "word "
+    prompt_4 = prompt * 1023
+    num_beams_4 = dynamic_num_beams(prompt_4, tokenizer)
+    assert num_beams_4 == 4
+    prompt_2 = prompt * 1535
+    num_beams_2 = dynamic_num_beams(prompt_2, tokenizer)
+    assert num_beams_2 == 2
+    prompt_1 = prompt * 2048
+    num_beams_1 = dynamic_num_beams(prompt_1, tokenizer)
+    assert num_beams_1 == 1

--- a/tests/test_utils_pruning.py
+++ b/tests/test_utils_pruning.py
@@ -1,0 +1,94 @@
+import pytest
+from utils.pruning import encoder, get_entity_types, get_md_emb
+
+
+@pytest.fixture
+def test_metadata():
+    column_csv = [
+        "country.name,text,country name",
+        "country.capital,text,country capital",
+        "country.id,integer,unique id for country, not iso code",
+        "airport.country_id,integer,unique id for country where airport is located in",
+        "airport.airport_name,text,name of airport",
+        "flight.pilot_name,text,name of the pilot",
+        "flight.airport_name,text,name of the airport",
+        "flight.flight_code,text,flight code",
+    ]
+    column_emb = encoder.encode(column_csv, convert_to_tensor=True)
+    column_ner = {
+        "GPE": [
+            "country.name,text,country name",
+            "country.capital,text,country capital",
+            "airport.country_name,text,name of the country where the airport is located in",
+        ],
+        "ORG": [
+            "country.name,text,country name",
+            "airport.airport_name,text,name of airport",
+            "flight.airport_name,text,name of the airport",
+        ],
+        "PERSON": ["flight.pilot_name,text,name of the pilot"],
+    }
+    column_join = {("airport", "country"): [("airport.country_id", "country.id")]}
+    return column_emb, column_csv, column_ner, column_join
+
+
+# test embedding results + ner + join columns for sql
+def test_get_md_emb(test_metadata):
+    column_emb, column_csv, column_ner, column_join = test_metadata
+    question = "How many flights start from Los Angeles Airport (LAX)?"
+    assert get_entity_types(question) == {"GPE", "ORG"}
+    k = 3
+    threshold = 0.0
+
+    # Call the function and get the result
+    result = get_md_emb(
+        question,
+        column_emb,
+        column_csv,
+        column_ner,
+        column_join,
+        k,
+        threshold,
+    )
+    print(f"result\n{result}")
+    expected = """```
+CREATE TABLE flight (
+  airport_name text, --name of the airport
+  flight_code text, --flight code
+);
+CREATE TABLE airport (
+  airport_name text, --name of airport
+  country_name text, --name of the country where the airport is located in
+  country_id integer, --unique id for country where airport is located in
+);
+CREATE TABLE country (
+  name text, --country name
+  capital text, --country capital
+  id integer, --unique id for country, not iso code
+);
+```
+
+Additionally, the following are tables/column pairs that can be joined in this database:
+```
+airport.country_id can be joined with country.id
+```"""
+    assert result == expected
+
+
+def test_get_md_emb_sql_emb_empty(test_metadata):
+    column_emb, column_csv, column_ner, column_join = test_metadata
+    question = "Who ate my homework?"
+    k = 3
+    threshold = 1.0  # arbitrarily high threshold to test empty results
+
+    # Call the function and get the result
+    result = get_md_emb(
+        question,
+        column_emb,
+        column_csv,
+        column_ner,
+        column_join,
+        k,
+        threshold,
+    )
+    assert result == ""

--- a/utils/pruning.py
+++ b/utils/pruning.py
@@ -56,6 +56,8 @@ def get_entity_types(sentence, verbose: bool = False):
 def format_topk_sql(
     topk_table_columns: Dict[str, List[Tuple[str, str, str]]],
 ) -> str:
+    if len(topk_table_columns) == 0:
+        return ""
     md_str = "```\n"
     for table_name in topk_table_columns:
         columns_str = ""
@@ -66,7 +68,7 @@ def format_topk_sql(
                 )
             else:
                 columns_str += f"\n  {column_tuple[0]} {column_tuple[1]}, "
-        md_str += f"CREATE TABLE {table_name} ({columns_str}\n)\n-----------\n"
+        md_str += f"CREATE TABLE {table_name} ({columns_str}\n);\n"
     return md_str
 
 
@@ -155,7 +157,7 @@ def get_md_emb(
     # 4) format metadata string
     md_str = format_topk_sql(topk_table_columns)
 
-    if join_list:
+    if len(join_list) > 0:
         md_str += "```\n\nAdditionally, the following are tables/column pairs that can be joined in this database:\n```\n"
         md_str += "\n".join(join_list)
         md_str += "\n```"
@@ -167,10 +169,8 @@ def prune_metadata_str(question, db_name, public_data=True):
     root_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
     emb_path = os.path.join(root_dir, "data", "embeddings.pkl")
     if public_data:
-        print("Loading public data")
         import defog_data.supplementary as sup
     else:
-        print("Loading private data")
         import defog_data_private.supplementary as sup
     emb, csv_descriptions = sup.load_embeddings(emb_path)
     table_metadata_csv = get_md_emb(


### PR DESCRIPTION
- Use dynamic number of beams depending on the prompt's token length. We scale it down approximately quadratically due to the quadratic nature of attention. We now no longer need the statements to explicitly deal with torch memory before the generate statement.
- Update prompt to be the same as sql-coder.
- Add tests.

Verified that the latest fix is able to work with the following command:
```
$ python main.py \
  -q data/questions_gen.csv \
  -o "results/defog_sqlcoder_npl_short_stratified2_best.csv" \
  -g hf \
  -f prompts/prompt.md \
  -m /home/defog/finetuning/starcoder/defog_sqlcoder_npl_short_stratified2/best
...
Correct so far: 145/200 (72.50%): 100%|█████████████████████████████████████████████████| 200/200 [08:49<00:00,  2.65s/it]
                exact_match   correct
query_category                       
date_functions     0.600000  0.600000
group_by           0.857143  0.885714
order_by           0.685714  0.800000
ratio              0.514286  0.600000
table_join         0.771429  0.800000
where              0.600000  0.628571
```
