### PR TITLE
Save embeddings for private and public data separately

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 data/postgres
-data/embeddings.pkl
+data/*embeddings.pkl
 results
 
 # pycache

--- a/utils/pruning.py
+++ b/utils/pruning.py
@@ -167,11 +167,14 @@ def get_md_emb(
 def prune_metadata_str(question, db_name, public_data=True):
     # current file dir
     root_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
-    emb_path = os.path.join(root_dir, "data", "embeddings.pkl")
     if public_data:
         import defog_data.supplementary as sup
+
+        emb_path = os.path.join(root_dir, "data", "public_embeddings.pkl")
     else:
         import defog_data_private.supplementary as sup
+
+        emb_path = os.path.join(root_dir, "data", "private_embeddings.pkl")
     emb, csv_descriptions = sup.load_embeddings(emb_path)
     table_metadata_csv = get_md_emb(
         question,


### PR DESCRIPTION
Save embeddings for private and public data separately so that we wouldn't accidentally reference the wrong one when switching between the 2.