### PR TITLE
Add vllm runner

### DIFF
--- a/eval/vllm_runner.py
+++ b/eval/vllm_runner.py
@@ -1,0 +1,118 @@
+import sqlparse
+from vllm import LLM, SamplingParams
+from eval.eval import compare_query_results
+import pandas as pd
+from utils.pruning import prune_metadata_str
+from utils.questions import prepare_questions_df
+import time
+import torch
+from transformers import AutoTokenizer
+from tqdm import tqdm
+
+
+def generate_prompt(prompt_file, question, db_name, public_data):
+    with open(prompt_file, "r") as f:
+        prompt = f.read()
+
+    pruned_metadata_str = prune_metadata_str(question, db_name, public_data)
+    prompt = prompt.format(
+        user_question=question, table_metadata_string=pruned_metadata_str
+    )
+    return prompt
+
+
+def run_vllm_eval(args):
+    # get params from args
+    questions_file = args.questions_file
+    prompt_file = args.prompt_file
+    num_questions = args.num_questions
+    public_data = not args.use_private_data
+    model_name = args.model
+    output_file = args.output_file
+    num_beams = args.num_beams
+
+    # get questions
+    print(
+        f"Preparing {'all' if num_questions is None else num_questions} questions from {questions_file}"
+    )
+    df = prepare_questions_df(questions_file, num_questions)
+
+    # create a prompt for each question
+    df["prompt"] = df[["question", "db_name"]].apply(
+        lambda row: generate_prompt(
+            prompt_file, row["question"], row["db_name"], public_data
+        ),
+        axis=1,
+    )
+
+    print(f"Preparing {model_name}")
+    tokenizer = AutoTokenizer.from_pretrained(model_name)
+    llm = LLM(model=model_name, tensor_parallel_size=torch.cuda.device_count())
+
+    sampling_params = SamplingParams(
+        n=1,
+        best_of=num_beams,
+        use_beam_search=num_beams != 1,
+        stop_token_ids=[tokenizer.eos_token_id],
+        max_tokens=300,
+        temperature=0,
+    )
+
+    print(f"Generating {len(df)} completions")
+    start_time = time.time()
+    outputs = llm.generate(df["prompt"].tolist(), sampling_params)
+    time_taken = time.time() - start_time
+    print(f"Time taken: {time_taken:.1f}s")
+
+    df["generated_query"] = ""
+    df["correct"] = 0
+    df["exact_match"] = 0
+    df["error_db_exec"] = 0
+    df["error_msg"] = ""
+    total_correct = 0
+    with tqdm(total=len(df)) as pbar:
+        for i, output in enumerate(outputs):
+            generated_query = output.outputs[0].text.split(";")[0].strip()
+            normalized_query = sqlparse.format(
+                generated_query, keyword_case="upper", strip_whitespace=True
+            )
+            df.loc[i, "generated_query"] = normalized_query
+            df.loc[i, "latency_seconds"] = time_taken / len(df)
+            row = df.iloc[i]
+            golden_query = row["query"]
+            db_name = row["db_name"]
+            question = row["question"]
+            query_category = row["query_category"]
+            exact_match = correct = 0
+            db_creds = {
+                "host": "localhost",
+                "port": 5432,
+                "user": "postgres",
+                "password": "postgres",
+                "database": db_name,
+            }
+            try:
+                exact_match, correct = compare_query_results(
+                    query_gold=golden_query,
+                    query_gen=generated_query,
+                    db_name=db_name,
+                    db_creds=db_creds,
+                    question=question,
+                    query_category=query_category,
+                )
+                df.loc[i, "exact_match"] = int(exact_match)
+                df.loc[i, "correct"] = int(correct)
+                df.loc[i, "error_msg"] = ""
+                if correct:
+                    total_correct += 1
+            except Exception as e:
+                df.loc[i, "error_db_exec"] = 1
+                df.loc[i, "error_msg"] = f"QUERY EXECUTION ERROR: {e}"
+            pbar.update(1)
+            pbar.set_description(
+                f"Correct so far: {total_correct}/{(i+1)} ({100*total_correct/(i+1):.2f}%)"
+            )
+    del df["prompt"]
+    print(df.groupby("query_category")[["exact_match", "correct"]].mean())
+    df = df.sort_values(by=["db_name", "query_category", "question"])
+    df.to_csv(output_file, index=False, float_format="%.2f")

--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 from eval.openai_runner import run_openai_eval
 from eval.hf_runner import run_hf_eval
 from eval.anthropic_runner import run_anthropic_eval
+from eval.vllm_runner import run_vllm_eval
 import argparse
 
 if __name__ == "__main__":
@@ -10,6 +11,7 @@ if __name__ == "__main__":
     parser.add_argument("-g", "--model_type", type=str, required=True)
     parser.add_argument("-m", "--model", type=str)
     parser.add_argument("-a", "--adapter", type=str)
+    parser.add_argument("-b", "--num_beams", type=int, default=4)
     parser.add_argument("-f", "--prompt_file", type=str, required=True)
     parser.add_argument("-d", "--use_private_data", action="store_true")
     parser.add_argument("-o", "--output_file", type=str, required=True)
@@ -28,6 +30,8 @@ if __name__ == "__main__":
         if args.model is None:
             args.model = "claude-2"
         run_anthropic_eval(args)
+    elif args.model_type == "vllm":
+        run_vllm_eval(args)
     elif args.model_type == "hf":
         run_hf_eval(args)
     else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ tiktoken
 torch
 tqdm
 transformers
+vllm


### PR DESCRIPTION
Add runner with vllm.
We now give users the option to run their evals with vllm, which could be faster. vLLM supports batched generation which is much faster, and so we batch all of our queries at the start, and then verify the db correctness after all completions have been generated.
Tested with 4xA10's with a 34B CodeLlama derivative and it worked well with num_beams = 4, taking only 290s to generate completions for 200 questions. Total time taken (including model loading) was just over 6 mins.