### PR TITLE
Added an option to let users make a call to any external API with a prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Having implemented the query generator, the next piece of abstraction would be t
 ### OpenAI
 Remember to have your OpenAI API key (`OPENAI_API_KEY="sk-..."`) set as an environment variable before running the test if you plan to call the OpenAI API (or Anthropic/other LLM API's accordingly).
 
-To test it out with just 10 questions (instead of all 175), parallelized across 5 :
+To test it out with just 10 questions (instead of all 200), parallelized across 5 :
 
 ```bash
 mkdir results # create directory for storing results
@@ -119,7 +119,7 @@ python main.py \
 ```
 
 ### Hugging Face
-To test it out with our fine-tuned sql model with just 10 questions (instead of all 175):
+To test it out with our fine-tuned sql model with just 10 questions (instead of all 200):
 
 ```bash
 mkdir results #create directory for storing results
@@ -134,6 +134,20 @@ python -W ignore main.py \
   -n 10
 ```
 
+### API
+To test it out with just 10 questions (instead of all 200), parallelized across 3 calls:
+```bash
+mkdir results
+python main.py \
+  -q data/questions_gen.csv \
+  -o results/results.csv \
+  -g api \
+  -b 5 \
+  -f prompts/prompt.md \
+  --url YOUR_API_URL \
+  -p 3 \
+  -n 10
+```
 
 ### CLI Flags
 You can use the following flags in the command line to change the configurations of your evaluation runs.
@@ -141,8 +155,9 @@ You can use the following flags in the command line to change the configurations
 |-------------|-------|
 |  -q, --questions_file   |  CSV file that contains the test questions and true queries.   |
 | -n, --num_questions  |  Use this to limit the total number of questions you want to test.  |
-|  -g, --model_type   |  Model type used. Make sure this matches the model used. Currently defined options in `main.py` are `oa` for OpenAI models and `hf` for Hugging Face models.   |
+|  -g, --model_type   |  Model type used. Make sure this matches the model used. Currently defined options in `main.py` are `oa` for OpenAI models, `anthropic` for Anthropic models, `hf` for Hugging Face models, and `api` for API endpoints.   |
 |  -m, --model   |  Model that will be tested and used to generate the queries. Currently defined options for OpenAI models are chat models `gpt-3.5-turbo-0613` and `gpt-4-0613`, and non-chat model `text-davinci-003`. For Hugging Face models, simply use the path of your chosen model (e.g. `defog/sqlcoder`).  |
+|  --url   |  The URL of the API you want to send the prompt to. Only used when model_type is `api` |
 |  -f, --prompt_file   |  Markdown file with the prompt used for query generation.  |
 |  -d, --use_private_data  |  Use this to read from your own private data library.  |
 |  -o, --output_file   |  Output CSV file that will store your results.   |

--- a/eval/api_runner.py
+++ b/eval/api_runner.py
@@ -7,6 +7,7 @@ from tqdm import tqdm
 from time import time
 import requests
 
+
 def generate_prompt(prompt_file, question, db_name, public_data):
     with open(prompt_file, "r") as f:
         prompt = f.read()
@@ -16,6 +17,7 @@ def generate_prompt(prompt_file, question, db_name, public_data):
         user_question=question, table_metadata_string=pruned_metadata_str
     )
     return prompt
+
 
 def run_api_eval(args):
     # get params from args
@@ -52,17 +54,27 @@ def run_api_eval(args):
             start_time = time()
             # we set return_full_text to False so that we don't get the prompt text in the generated text
             # this simplifies our postprocessing to deal with just the truncation of the end of the query
-            r = requests.post(api_url, json={
-                "prompt": row["prompt"],
-                "use_beam_search": True,
-                "n": 1,
-                "best_of": num_beams,
-                "temperature": 0,
-                "stop": [";", "```"],
-                "max_tokens": 600
-            })
+            r = requests.post(
+                api_url,
+                json={
+                    "prompt": row["prompt"],
+                    "use_beam_search": True,
+                    "n": 1,
+                    "best_of": num_beams,
+                    "temperature": 0,
+                    "stop": [";", "```"],
+                    "max_tokens": 600,
+                },
+            )
             end_time = time()
-            generated_query = r.json()['text'][0].split("```")[-1].split("```")[0].split(";")[0].strip() + ";"
+            generated_query = (
+                r.json()["text"][0]
+                .split("```")[-1]
+                .split("```")[0]
+                .split(";")[0]
+                .strip()
+                + ";"
+            )
 
             row["generated_query"] = generated_query
             row["latency_seconds"] = end_time - start_time

--- a/eval/api_runner.py
+++ b/eval/api_runner.py
@@ -1,0 +1,110 @@
+from typing import Optional
+from eval.eval import compare_query_results
+import pandas as pd
+from utils.pruning import prune_metadata_str
+from utils.questions import prepare_questions_df
+from tqdm import tqdm
+from time import time
+import requests
+
+def generate_prompt(prompt_file, question, db_name, public_data):
+    with open(prompt_file, "r") as f:
+        prompt = f.read()
+
+    pruned_metadata_str = prune_metadata_str(question, db_name, public_data)
+    prompt = prompt.format(
+        user_question=question, table_metadata_string=pruned_metadata_str
+    )
+    return prompt
+
+def run_api_eval(args):
+    # get params from args
+    questions_file = args.questions_file
+    prompt_file = args.prompt_file
+    num_questions = args.num_questions
+    public_data = not args.use_private_data
+    api_url = args.url
+    output_file = args.output_file
+    num_beams = args.num_beams
+
+    print("preparing questions...")
+    # get questions
+    print(f"Using {num_questions} questions from {questions_file}")
+    df = prepare_questions_df(questions_file, num_questions)
+
+    # create a prompt for each question
+    df["prompt"] = df[["question", "db_name"]].apply(
+        lambda row: generate_prompt(
+            prompt_file, row["question"], row["db_name"], public_data
+        ),
+        axis=1,
+    )
+
+    print("questions prepared\nnow loading model...")
+    # initialize tokenizer and model
+    total_tried = 0
+    total_correct = 0
+    output_rows = []
+
+    with tqdm(total=len(df)) as pbar:
+        for row in df.to_dict("records"):
+            total_tried += 1
+            start_time = time()
+            # we set return_full_text to False so that we don't get the prompt text in the generated text
+            # this simplifies our postprocessing to deal with just the truncation of the end of the query
+            r = requests.post(api_url, json={
+                "prompt": row["prompt"],
+                "use_beam_search": True,
+                "n": 1,
+                "best_of": num_beams,
+                "temperature": 0,
+                "stop": [";", "```"],
+                "max_tokens": 600
+            })
+            end_time = time()
+            generated_query = r.json()['text'][0].split("```")[-1].split("```")[0].split(";")[0].strip() + ";"
+
+            row["generated_query"] = generated_query
+            row["latency_seconds"] = end_time - start_time
+            golden_query = row["query"]
+            db_name = row["db_name"]
+            question = row["question"]
+            query_category = row["query_category"]
+            exact_match = correct = 0
+            db_creds = {
+                "host": "localhost",
+                "port": 5432,
+                "user": "postgres",
+                "password": "postgres",
+                "database": db_name,
+            }
+
+            try:
+                exact_match, correct = compare_query_results(
+                    query_gold=golden_query,
+                    query_gen=generated_query,
+                    db_name=db_name,
+                    db_creds=db_creds,
+                    question=question,
+                    query_category=query_category,
+                )
+                row["exact_match"] = int(exact_match)
+                row["correct"] = int(correct)
+                row["error_msg"] = ""
+                if correct:
+                    total_correct += 1
+            except Exception as e:
+                row["error_db_exec"] = 1
+                row["error_msg"] = f"QUERY EXECUTION ERROR: {e}"
+
+            output_rows.append(row)
+            pbar.update(1)
+            pbar.set_description(
+                f"Correct so far: {total_correct}/{total_tried} ({100*total_correct/total_tried:.2f}%)"
+            )
+
+    output_df = pd.DataFrame(output_rows)
+    del output_df["prompt"]
+    print(output_df.groupby("query_category")[["exact_match", "correct"]].mean())
+    output_df = output_df.sort_values(by=["db_name", "query_category", "question"])
+    output_df.to_csv(output_file, index=False, float_format="%.2f")

--- a/eval/api_runner.py
+++ b/eval/api_runner.py
@@ -20,10 +20,8 @@ def generate_prompt(prompt_file, question, db_name, public_data):
     return prompt
 
 
-def process_row(row, api_url, num_beams, public_data):
+def process_row(row, api_url, num_beams):
     start_time = time()
-    # we set return_full_text to False so that we don't get the prompt text in the generated text
-    # this simplifies our postprocessing to deal with just the truncation of the end of the query
     r = requests.post(
         api_url,
         json={
@@ -109,9 +107,7 @@ def run_api_eval(args):
     with ThreadPoolExecutor(max_workers=5) as executor:
         futures = []
         for row in df.to_dict("records"):
-            futures.append(
-                executor.submit(process_row, row, api_url, num_beams, public_data)
-            )
+            futures.append(executor.submit(process_row, row, api_url, num_beams))
 
         with tqdm(as_completed(futures), total=len(futures)) as pbar:
             for f in pbar:

--- a/eval/api_runner.py
+++ b/eval/api_runner.py
@@ -1,3 +1,4 @@
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Optional
 from eval.eval import compare_query_results
 import pandas as pd
@@ -19,6 +20,62 @@ def generate_prompt(prompt_file, question, db_name, public_data):
     return prompt
 
 
+def process_row(row, api_url, num_beams, public_data):
+    start_time = time()
+    # we set return_full_text to False so that we don't get the prompt text in the generated text
+    # this simplifies our postprocessing to deal with just the truncation of the end of the query
+    r = requests.post(
+        api_url,
+        json={
+            "prompt": row["prompt"],
+            "n": 1,
+            "use_beam_search": True,
+            "best_of": num_beams,
+            "temperature": 0,
+            "stop": [";", "```"],
+            "max_tokens": 600,
+        },
+    )
+    end_time = time()
+    generated_query = (
+        r.json()["text"][0].split("```")[-1].split("```")[0].split(";")[0].strip() + ";"
+    )
+
+    row["generated_query"] = generated_query
+    row["latency_seconds"] = end_time - start_time
+    golden_query = row["query"]
+    db_name = row["db_name"]
+    question = row["question"]
+    query_category = row["query_category"]
+    exact_match = correct = 0
+
+    db_creds = {
+        "host": "localhost",
+        "port": 5432,
+        "user": "postgres",
+        "password": "postgres",
+        "database": db_name,
+    }
+
+    try:
+        exact_match, correct = compare_query_results(
+            query_gold=golden_query,
+            query_gen=generated_query,
+            db_name=db_name,
+            db_creds=db_creds,
+            question=question,
+            query_category=query_category,
+        )
+        row["exact_match"] = int(exact_match)
+        row["correct"] = int(correct)
+        row["error_msg"] = ""
+    except Exception as e:
+        row["error_db_exec"] = 1
+        row["error_msg"] = f"QUERY EXECUTION ERROR: {e}"
+
+    return row
+
+
 def run_api_eval(args):
     # get params from args
     questions_file = args.questions_file
@@ -28,6 +85,7 @@ def run_api_eval(args):
     api_url = args.url
     output_file = args.output_file
     num_beams = args.num_beams
+    max_workers = args.parallel_threads
 
     print("preparing questions...")
     # get questions
@@ -48,72 +106,24 @@ def run_api_eval(args):
     total_correct = 0
     output_rows = []
 
-    with tqdm(total=len(df)) as pbar:
+    with ThreadPoolExecutor(max_workers=5) as executor:
+        futures = []
         for row in df.to_dict("records"):
-            total_tried += 1
-            start_time = time()
-            # we set return_full_text to False so that we don't get the prompt text in the generated text
-            # this simplifies our postprocessing to deal with just the truncation of the end of the query
-            r = requests.post(
-                api_url,
-                json={
-                    "prompt": row["prompt"],
-                    "use_beam_search": True,
-                    "n": 1,
-                    "best_of": num_beams,
-                    "temperature": 0,
-                    "stop": [";", "```"],
-                    "max_tokens": 600,
-                },
-            )
-            end_time = time()
-            generated_query = (
-                r.json()["text"][0]
-                .split("```")[-1]
-                .split("```")[0]
-                .split(";")[0]
-                .strip()
-                + ";"
+            futures.append(
+                executor.submit(process_row, row, api_url, num_beams, public_data)
             )
 
-            row["generated_query"] = generated_query
-            row["latency_seconds"] = end_time - start_time
-            golden_query = row["query"]
-            db_name = row["db_name"]
-            question = row["question"]
-            query_category = row["query_category"]
-            exact_match = correct = 0
-            db_creds = {
-                "host": "localhost",
-                "port": 5432,
-                "user": "postgres",
-                "password": "postgres",
-                "database": db_name,
-            }
-
-            try:
-                exact_match, correct = compare_query_results(
-                    query_gold=golden_query,
-                    query_gen=generated_query,
-                    db_name=db_name,
-                    db_creds=db_creds,
-                    question=question,
-                    query_category=query_category,
-                )
-                row["exact_match"] = int(exact_match)
-                row["correct"] = int(correct)
-                row["error_msg"] = ""
-                if correct:
+        with tqdm(as_completed(futures), total=len(futures)) as pbar:
+            for f in pbar:
+                row = f.result()
+                output_rows.append(row)
+                if row["correct"]:
                     total_correct += 1
-            except Exception as e:
-                row["error_db_exec"] = 1
-                row["error_msg"] = f"QUERY EXECUTION ERROR: {e}"
-
-            output_rows.append(row)
-            pbar.update(1)
-            pbar.set_description(
-                f"Correct so far: {total_correct}/{total_tried} ({100*total_correct/total_tried:.2f}%)"
-            )
+                total_tried += 1
+                pbar.update(1)
+                pbar.set_description(
+                    f"Correct so far: {total_correct}/{total_tried} ({100*total_correct/total_tried:.2f}%)"
+                )
 
     output_df = pd.DataFrame(output_rows)
     del output_df["prompt"]

--- a/main.py
+++ b/main.py
@@ -7,6 +7,7 @@ if __name__ == "__main__":
     parser.add_argument("-g", "--model_type", type=str, required=True)
     parser.add_argument("-m", "--model", type=str)
     parser.add_argument("-a", "--adapter", type=str)
+    parser.add_argument("--url", type=str)
     parser.add_argument("-b", "--num_beams", type=int, default=4)
     parser.add_argument("-f", "--prompt_file", type=str, required=True)
     parser.add_argument("-d", "--use_private_data", action="store_true")
@@ -38,6 +39,10 @@ if __name__ == "__main__":
         from eval.hf_runner import run_hf_eval
 
         run_hf_eval(args)
+    elif args.model_type == "api":
+        from eval.api_runner import run_api_eval
+
+        run_api_eval(args)
     else:
         raise ValueError(
             f"Invalid model type: {args.model_type}. Model type must be one of: 'oa', 'hf'"

--- a/prompts/prompt.md
+++ b/prompts/prompt.md
@@ -1,15 +1,11 @@
-### Task
+# Task
 Generate a SQL query to answer the following question:
 `{user_question}`
 
-### Database Schema
+# Database Schema
 The query will run on a database with the following schema:
 {table_metadata_string}
 
-### SQL
-Follow these steps to create the SQL Query:
-1. Only use the columns and tables present in the database schema
-2. Use table aliases to prevent ambiguity when doing joins. For example, `SELECT table1.col1, table2.col1 FROM table1 JOIN table2 ON table1.id = table2.id`.
-
-Given the database schema, here is the SQL query that answers `{user_question}`:
-```sql
+# SQL
+Here is the query to answer the question `{user_question}`
+```

--- a/query_generators/openai.py
+++ b/query_generators/openai.py
@@ -43,7 +43,7 @@ class OpenAIQueryGenerator(QueryGenerator):
         temperature=0,
         stop=[],
         logit_bias={},
-        seed=123,
+        seed=100,
     ):
         """Get OpenAI chat completion for a given prompt and model"""
         generated_text = ""
@@ -55,6 +55,7 @@ class OpenAIQueryGenerator(QueryGenerator):
                 temperature=temperature,
                 stop=stop,
                 logit_bias=logit_bias,
+                seed=seed,
             )
             generated_text = completion.choices[0].message.content
         except Exception as e:


### PR DESCRIPTION
This will be useful if - say - one wants to test multiple or inference strategies on a LLM that is hosted on a server. Currently, this can be used to send requests to a hosted vLLM server.

I tested this with `python main.py -g api -q data/questions_gen.csv -b 5 -f prompts/prompt.md --url MY_VLLM_SERVER_URL -o results/results.csv`