### PR TITLE
Removed public data flag

### DIFF
--- a/eval/api_runner.py
+++ b/eval/api_runner.py
@@ -9,11 +9,11 @@ from time import time
 import requests
 
 
-def generate_prompt(prompt_file, question, db_name, public_data):
+def generate_prompt(prompt_file, question, db_name):
     with open(prompt_file, "r") as f:
         prompt = f.read()
 
-    pruned_metadata_str = prune_metadata_str(question, db_name, public_data)
+    pruned_metadata_str = prune_metadata_str(question, db_name)
     prompt = prompt.format(
         user_question=question, table_metadata_string=pruned_metadata_str
     )
@@ -79,7 +79,6 @@ def run_api_eval(args):
     questions_file = args.questions_file
     prompt_file_list = args.prompt_file
     num_questions = args.num_questions
-    public_data = not args.use_private_data
     api_url = args.url
     output_file_list = args.output_file
     num_beams = args.num_beams
@@ -94,7 +93,7 @@ def run_api_eval(args):
         # create a prompt for each question
         df["prompt"] = df[["question", "db_name"]].apply(
             lambda row: generate_prompt(
-                prompt_file, row["question"], row["db_name"], public_data
+                prompt_file, row["question"], row["db_name"]
             ),
             axis=1,
         )

--- a/eval/hf_runner.py
+++ b/eval/hf_runner.py
@@ -19,11 +19,11 @@ import gc
 from peft import PeftModel, PeftConfig
 
 
-def generate_prompt(prompt_file, question, db_name, public_data):
+def generate_prompt(prompt_file, question, db_name):
     with open(prompt_file, "r") as f:
         prompt = f.read()
 
-    pruned_metadata_str = prune_metadata_str(question, db_name, public_data)
+    pruned_metadata_str = prune_metadata_str(question, db_name)
     prompt = prompt.format(
         user_question=question, table_metadata_string=pruned_metadata_str
     )
@@ -90,7 +90,6 @@ def run_hf_eval(args):
     questions_file = args.questions_file
     prompt_file_list = args.prompt_file
     num_questions = args.num_questions
-    public_data = not args.use_private_data
     model_name = args.model
     adapter_path = args.adapter
     output_file_list = args.output_file
@@ -119,7 +118,7 @@ def run_hf_eval(args):
         # create a prompt for each question
         df["prompt"] = df[["question", "db_name"]].apply(
             lambda row: generate_prompt(
-                prompt_file, row["question"], row["db_name"], public_data
+                prompt_file, row["question"], row["db_name"]
             ),
             axis=1,
         )

--- a/eval/openai_runner.py
+++ b/eval/openai_runner.py
@@ -38,7 +38,6 @@ def run_openai_eval(args):
                     model=args.model,
                     prompt_file=prompt_file,
                     timeout=args.timeout_gen,
-                    use_public_data=not args.use_private_data,
                     verbose=args.verbose,
                 )
 

--- a/eval/vllm_runner.py
+++ b/eval/vllm_runner.py
@@ -11,11 +11,11 @@ from transformers import AutoTokenizer
 from tqdm import tqdm
 
 
-def generate_prompt(prompt_file, question, db_name, public_data):
+def generate_prompt(prompt_file, question, db_name):
     with open(prompt_file, "r") as f:
         prompt = f.read()
 
-    pruned_metadata_str = prune_metadata_str(question, db_name, public_data)
+    pruned_metadata_str = prune_metadata_str(question, db_name)
     prompt = prompt.format(
         user_question=question, table_metadata_string=pruned_metadata_str
     )
@@ -27,7 +27,6 @@ def run_vllm_eval(args):
     questions_file = args.questions_file
     prompt_file_list = args.prompt_file
     num_questions = args.num_questions
-    public_data = not args.use_private_data
     model_name = args.model
     output_file_list = args.output_file
     num_beams = args.num_beams
@@ -52,7 +51,7 @@ def run_vllm_eval(args):
         df = prepare_questions_df(questions_file, num_questions)
         df["prompt"] = df[["question", "db_name"]].apply(
             lambda row: generate_prompt(
-                prompt_file, row["question"], row["db_name"], public_data
+                prompt_file, row["question"], row["db_name"]
             ),
             axis=1,
         )

--- a/main.py
+++ b/main.py
@@ -11,7 +11,6 @@ if __name__ == "__main__":
     parser.add_argument("-b", "--num_beams", type=int, default=4)
     # take in a list of prompt files
     parser.add_argument("-f", "--prompt_file", nargs="+", type=str, required=True)
-    parser.add_argument("-d", "--use_private_data", action="store_true")
     parser.add_argument("-o", "--output_file", nargs="+", type=str, required=True)
     parser.add_argument("-p", "--parallel_threads", type=int, default=5)
     parser.add_argument("-t", "--timeout_gen", type=float, default=30.0)

--- a/query_generators/openai.py
+++ b/query_generators/openai.py
@@ -22,7 +22,6 @@ class OpenAIQueryGenerator(QueryGenerator):
         model: str,
         prompt_file: str,
         timeout: int,
-        use_public_data: bool,
         verbose: bool,
         **kwargs,
     ):
@@ -30,7 +29,6 @@ class OpenAIQueryGenerator(QueryGenerator):
         self.db_name = db_creds["database"]
         self.model = model
         self.prompt_file = prompt_file
-        self.use_public_data = use_public_data
 
         self.timeout = timeout
         self.verbose = verbose
@@ -125,7 +123,7 @@ class OpenAIQueryGenerator(QueryGenerator):
             user_prompt = user_prompt.format(
                 user_question=question,
                 table_metadata_string=prune_metadata_str(
-                    question, self.db_name, self.use_public_data
+                    question, self.db_name
                 ),
             )
 


### PR DESCRIPTION
Remove flag for public data. We now automatically infer whether db is public based on the name's membership in `defog_data.metadata.dbs`.
Tested with openai runner and vllm and both work. Tested vllm with a csv test dataset containing public and private dbs and it handled the running correctly.
```sh
$ python main.py \                        
  -q data/questions_gen.csv \
  -o results/my_query_generator.csv \
  -g oa \
  -f prompts/prompt_openai.md \
  -m gpt-3.5-turbo-0613 \
  -n 10 \
  -p 5
preparing questions...
Correct so far: 9/10 (90.00%): 100%|█████████████████████████████████████████████████████████████████████████████████████| 10/10 [00:03<00:00,  3.16it/s]
                exact_match  correct
query_category                      
date_functions          1.0      1.0
group_by                0.8      0.8
Average correct rate: 0.90
```