### PR TITLE
Updated handling of instructions

### DIFF
--- a/eval/api_runner.py
+++ b/eval/api_runner.py
@@ -2,22 +2,11 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Optional
 from eval.eval import compare_query_results
 import pandas as pd
-from utils.pruning import prune_metadata_str
+from utils.pruning import generate_prompt
 from utils.questions import prepare_questions_df
 from tqdm import tqdm
 from time import time
 import requests
-
-
-def generate_prompt(prompt_file, question, db_name):
-    with open(prompt_file, "r") as f:
-        prompt = f.read()
-
-    pruned_metadata_str = prune_metadata_str(question, db_name)
-    prompt = prompt.format(
-        user_question=question, table_metadata_string=pruned_metadata_str
-    )
-    return prompt
 
 
 def process_row(row, api_url, num_beams):
@@ -92,7 +81,9 @@ def run_api_eval(args):
     for prompt_file, output_file in zip(prompt_file_list, output_file_list):
         # create a prompt for each question
         df["prompt"] = df[["question", "db_name"]].apply(
-            lambda row: generate_prompt(prompt_file, row["question"], row["db_name"]),
+            lambda row: generate_prompt(
+                prompt_file, row["question"], row["db_name"], row["instructions"]
+            ),
             axis=1,
         )
 

--- a/eval/openai_runner.py
+++ b/eval/openai_runner.py
@@ -40,9 +40,10 @@ def run_openai_eval(args):
                     timeout=args.timeout_gen,
                     verbose=args.verbose,
                 )
-
                 generated_query_fut = executor.submit(
-                    qg.generate_query, question=row["question"]
+                    qg.generate_query,
+                    question=row["question"],
+                    instructions=row["instructions"],
                 )
                 futures.append(generated_query_fut)
 

--- a/prompts/README.md
+++ b/prompts/README.md
@@ -1,17 +1,21 @@
 # Defining your prompt
-You can define your prompt using the following structure.
+You can define your prompt template by using the following variables:
+- `user_question`: The question that we want to generate sql for
+- `table_metadata_string`: The metadata of the table that we want to query. This is a string that contains the table names, column names and column types. This allows the model to know which columns/tables are available for getting information from. For the sqlcoder model that we released, you would need to represent your table metadata as a [SQL DDL](https://en.wikipedia.org/wiki/Data_definition_language) statement.
+- `instructions`: This is an optional field that allows you to customize specific instructions for each question, if needed. For example, if you want to ask the model to format your dates a particular way, define keywords, or adapt the SQL to a different database, you can do so here. If you don't need to customize the instructions, you can omit this in your prompt.
 
-```
-### Instructions:
-YOUR INSTRUCTIONS FOR THE MODEL
-
-### Input:
-Generate a SQL query that answers the question `{user_question}`.
-This query will run on a database whose schema is represented in this string:
+Here is how a sample might look like with the above variables:
+```markdown
+### Task
+Generate a SQL query to answer the following question:
+`{user_question}`
+`{instructions}`
+### Database Schema
+The query will run on a database with the following schema:
 {table_metadata_string}
 
-### Response:
-THE RESPONSE TEXT FOR THE MODEL
+### Answer
+Given the database schema, here is the SQL query that answers `{user_question}`:
 ```sql
 ```
 

--- a/prompts/prompt_instructions.md
+++ b/prompts/prompt_instructions.md
@@ -1,0 +1,11 @@
+### Task
+Generate a SQL query to answer the following question:
+`{user_question}`
+`{instructions}`
+### Database Schema
+The query will run on a database with the following schema:
+{table_metadata_string}
+
+### Answer
+Given the database schema, here is the SQL query that answers `{user_question}`:
+```sql

--- a/prompts/prompt_openai.md
+++ b/prompts/prompt_openai.md
@@ -3,6 +3,7 @@ Your task is to convert a text question to a SQL query that runs on Postgres, gi
 
 ### Input:
 Generate a SQL query that answers the question `{user_question}`.
+{instructions}
 
 This query will run on a database whose schema is represented in this string:
 {table_metadata_string}

--- a/query_generators/openai.py
+++ b/query_generators/openai.py
@@ -106,7 +106,7 @@ class OpenAIQueryGenerator(QueryGenerator):
             num_tokens = len(tokenizer.encode(prompt))
         return num_tokens
 
-    def generate_query(self, question: str) -> dict:
+    def generate_query(self, question: str, instructions: str) -> dict:
         start_time = time.time()
         self.err = ""
         self.query = ""
@@ -122,6 +122,7 @@ class OpenAIQueryGenerator(QueryGenerator):
 
             user_prompt = user_prompt.format(
                 user_question=question,
+                instructions=instructions,
                 table_metadata_string=prune_metadata_str(question, self.db_name),
             )
 

--- a/utils/pruning.py
+++ b/utils/pruning.py
@@ -1,3 +1,4 @@
+import re
 from defog_data.metadata import dbs
 import os
 from typing import Dict, List, Tuple
@@ -190,3 +191,21 @@ def prune_metadata_str(question, db_name):
         sup.columns_join[db_name],
     )
     return table_metadata_csv
+
+
+def generate_prompt(prompt_file, question, db_name, instructions=None):
+    """
+    Given prompt template file path, question, and db_name, generate prompt.
+    We will run the pruning algorithm to get the metadata string for the db_name.
+    Instructions are optional, and if present, will have a section heading
+    appended for clarity in the prompt.
+    """
+    with open(prompt_file, "r") as f:
+        prompt = f.read()
+    pruned_metadata_str = prune_metadata_str(question, db_name)
+    prompt = prompt.format(
+        user_question=question,
+        table_metadata_string=pruned_metadata_str,
+        instructions=instructions,
+    )
+    return prompt

--- a/utils/questions.py
+++ b/utils/questions.py
@@ -4,6 +4,12 @@ import pandas as pd
 
 def prepare_questions_df(questions_file: str, num_questions: Optional[int] = None):
     question_query_df = pd.read_csv(questions_file, nrows=num_questions)
+    # optional instructions:
+    if "instructions" in question_query_df.columns:
+        question_query_df["instructions"] = question_query_df["instructions"].fillna("")
+    else:
+        question_query_df["instructions"] = ""
+    # add columns for standard metrics
     question_query_df["generated_query"] = ""
     question_query_df["reason"] = ""
     question_query_df["error_msg"] = ""


### PR DESCRIPTION
The openai and vllm runner now passes in the instructions into the prompt if provided.
We provide a separate prompt for instructions as a drop in replacement for prompt.md when dealing with instructions based datasets.

openai runner works as before (3.5 without instructions):
```sg
$ python main.py \
  -q data/questions_gen.csv \
  -o results/my_query_generator.csv \
  -g oa \
  -f prompts/prompt_openai.md \
  -m gpt-3.5-turbo-0613 \
  -p 5
preparing questions...
Correct so far: 136/200 (68.00%): 100%|█████████████████████████| 200/200 [00:48<00:00,  4.09it/s]
                exact_match   correct
query_category                       
date_functions     0.760000  0.760000
group_by           0.800000  0.800000
order_by           0.657143  0.742857
ratio              0.257143  0.342857
table_join         0.714286  0.742857
where              0.714286  0.714286
Average correct rate: 0.68
```

3.5 now with instructions:
```sh
$ python main.py \
  -q data/questions_instruct.csv \
  -o results/my_query_generator.csv \
  -g oa \
  -f prompts/prompt_openai.md \
  -m gpt-3.5-turbo-0613 \
  -p 5
preparing questions...
Correct so far: 148/240 (61.67%): 100%|█████████████████████████| 240/240 [00:59<00:00,  4.06it/s]
                           exact_match   correct
query_category                                  
abbreviation_instructions     0.400000  0.466667
date_functions                0.760000  0.760000
date_instructions             0.200000  0.200000
group_by                      0.800000  0.800000
order_by                      0.657143  0.742857
ratio                         0.257143  0.342857
table_join                    0.714286  0.742857
where                         0.714286  0.714286
Average correct rate: 0.62
```

gpt-4 turbo with instructions:
```sh
$ python main.py \
  -q data/questions_instruct.csv \
  -o results/my_query_generator.csv \
  -g oa \
  -f prompts/prompt_openai.md \
  -m gpt-4-1106-preview \
  -p 5
preparing questions...
Correct so far: 180/240 (75.00%): 100%|██████████████████████████████████████████████████████████████████████████████████████| 240/240 [09:51<00:00,  2.47s/it]
                           exact_match   correct
query_category                                  
abbreviation_instructions     0.333333  0.400000
date_functions                0.800000  0.800000
date_instructions             0.360000  0.360000
group_by                      0.914286  0.942857
order_by                      0.828571  0.885714
ratio                         0.400000  0.685714
table_join                    0.800000  0.800000
where                         0.828571  0.828571
Average correct rate: 0.75
```

vllm with instructions:
```sh
python3 -W ignore main.py \
  -q data/questions_instruct.csv \
  -o "results/${model_name}_c${checkpoint_num}.csv" \
  -g vllm \
  -f "prompts/prompt_instructions.md" \
  -m "$model_path"
Preparing /models/combined/sqlcoder_7b_bf16_b16_ld005_r128_a128_ts/checkpoint-600
2023-11-30 12:55:04,457 INFO worker.py:1673 -- Started a local Ray instance.
INFO 11-30 12:55:05 llm_engine.py:72] Initializing an LLM engine with config: model='/models/combined/sqlcoder_7b_bf16_b16_ld005_r128_a128_ts/checkpoint-600', tokenizer='/models/combined/sqlcoder_7b_bf16_b16_ld005_r128_a128_ts/checkpoint-600', tokenizer_mode=auto, revision=None, tokenizer_revision=None, trust_remote_code=False, dtype=torch.float16, max_seq_len=16384, download_dir=None, load_format=auto, tensor_parallel_size=4, quantization=None, seed=0)
INFO 11-30 12:55:15 llm_engine.py:207] # GPU blocks: 8141, # CPU blocks: 2048
Using prompt file prompts/prompt_instructions.md
Prepared 240 questions from data/questions_instruct.csv
Generating completions
Processed prompts: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 240/240 [02:39<00:00,  1.51it/s]
Time taken: 159.4s
Correct so far: 174/240 (72.50%): 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████| 240/240 [00:04<00:00, 51.86it/s]
                           exact_match   correct
query_category                                  
abbreviation_instructions     0.333333  0.333333
date_functions                0.800000  0.800000
date_instructions             0.160000  0.160000
group_by                      0.857143  0.857143
order_by                      0.800000  0.914286
ratio                         0.771429  0.828571
table_join                    0.828571  0.828571
where                         0.714286  0.714286
Average tokens generated: 55.6
```