### PR TITLE
Caps `max_new_tokens` in the beam search check

### DIFF
--- a/eval/hf_runner.py
+++ b/eval/hf_runner.py
@@ -113,7 +113,7 @@ def run_hf_eval(args):
     pipe = pipeline("text-generation", model=model, tokenizer=tokenizer)
 
     support_beam_search = True
-    
+
     # check that the model supports beam search with a try except statement
     try:
         pipe("Hi", num_beams=2, do_sample=False, max_new_tokens=5)

--- a/eval/hf_runner.py
+++ b/eval/hf_runner.py
@@ -113,8 +113,10 @@ def run_hf_eval(args):
     pipe = pipeline("text-generation", model=model, tokenizer=tokenizer)
 
     support_beam_search = True
+    
+    # check that the model supports beam search with a try except statement
     try:
-        pipe("Hi", num_beams=2, do_sample=False)
+        pipe("Hi", num_beams=2, do_sample=False, max_new_tokens=5)
     except AttributeError as e:
         error_trace = traceback.format_exception(type(e), e, e.__traceback__)
         support_beam_search = (


### PR DESCRIPTION
Modifies code for checking if beam search is enabled in #62. This ensures that the models doesn't wastes too much of the user's time by generating very long pieces of text in this test step.