### PR TITLE
Added additional splitting on ``` substring in response parsing

### DIFF
--- a/eval/vllm_runner.py
+++ b/eval/vllm_runner.py
@@ -100,7 +100,9 @@ def run_vllm_eval(args):
         total_correct = 0
         with tqdm(total=len(df)) as pbar:
             for i, output in enumerate(outputs):
-                generated_query = output.outputs[0].text.split(";")[0].split("```")[0].strip()
+                generated_query = (
+                    output.outputs[0].text.split(";")[0].split("```")[0].strip()
+                )
                 normalized_query = sqlparse.format(
                     generated_query, keyword_case="upper", strip_whitespace=True
                 )

--- a/eval/vllm_runner.py
+++ b/eval/vllm_runner.py
@@ -100,7 +100,7 @@ def run_vllm_eval(args):
         total_correct = 0
         with tqdm(total=len(df)) as pbar:
             for i, output in enumerate(outputs):
-                generated_query = output.outputs[0].text.split(";")[0].strip()
+                generated_query = output.outputs[0].text.split(";")[0].split("```")[0].strip()
                 normalized_query = sqlparse.format(
                     generated_query, keyword_case="upper", strip_whitespace=True
                 )


### PR DESCRIPTION
Tiny fix to make `vllm` based evals more robust