### PR TITLE
Fixing normalize_table in compare_df

### DIFF
--- a/data/questions_gen_postgres.csv
+++ b/data/questions_gen_postgres.csv
@@ -566,7 +566,7 @@ EXAMPLE QUESTION 2: Which flights operate on Mondays and Wednesdays? Give me the
 EXAMPLE QUERY 2: SELECT flight.flight_number FROM flight WHERE LOWER(flight.flight_days) LIKE '%mon%' AND LOWER(flight.flight_days) LIKE '%wed%'
 
 "
-Which airlines offer flights with a stopover in Dallas?,"SELECT DISTINCT {airline.airline_name, airline.airline_code} FROM flight_stop JOIN airport ON flight_stop.stop_airport = airport.airport_code JOIN flight ON flight_stop.flight_id = flight.flight_id JOIN airline ON flight.airline_code = airline.airline_code WHERE airport.airport_location ILIKE '%Dallas%';",atis,table_join,"EXAMPLE QUESTION 1: Which airlines do not have any flights that depart or arrive at JFK or do not have stopovers?
+Which airlines offer flights with a stopover in Dallas?,"SELECT DISTINCT {airline.airline_name, airline.airline_code} FROM flight_stop JOIN airport ON flight_stop.stop_airport = airport.airport_code JOIN flight ON flight_stop.flight_id = flight.flight_id JOIN airline ON flight.airline_code = airline.airline_code WHERE airport.airport_location ILIKE '%Dallas%';",atis,table_join,"EXAMPLE QUESTION 1: Which airlines do not have any flights that either depart from/arrive at JFK, or have one or more stops?
 EXAMPLE QUERY 1: SELECT DISTINCT airline.airline_name FROM airline WHERE airline.airline_code NOT IN (SELECT flight.airline_code FROM flight WHERE flight.from_airport = 'JFK' OR flight.to_airport = 'JFK' OR flight.stops > 0)
 
 EXAMPLE QUESTION 2: Which airlines offer flights from LAX to ORD?
@@ -583,11 +583,11 @@ EXAMPLE QUERY 2: SELECT airline.airline_name, flight.stops FROM flight JOIN airl
 "Which airlines offer flights from Chicago (ORD) to New York (JFK), and how many stops do they have, sorted by number of stops in ascending order?","SELECT {airline.airline_name, airline.airline_code}, flight.stops FROM flight JOIN airline ON flight.airline_code = airline.airline_code WHERE flight.from_airport = 'ORD' AND flight.to_airport = 'JFK' GROUP BY {}, flight.stops ORDER BY flight.stops NULLS LAST;",atis,table_join,"EXAMPLE QUESTION 1: Which airlines offer flights from LAX to ORD?
 EXAMPLE QUERY 1: SELECT DISTINCT airline.airline_name FROM flight JOIN airline ON flight.airline_code = airline.airline_code WHERE flight.from_airport = 'LAX' AND flight.to_airport = 'ORD'
 
-EXAMPLE QUESTION 2: Which airlines do not have any flights that depart or arrive at JFK or do not have stopovers?
+EXAMPLE QUESTION 2: Which airlines do not have any flights that either depart from/arrive at JFK, or have one or more stops?
 EXAMPLE QUERY 2: SELECT DISTINCT airline.airline_name FROM airline WHERE airline.airline_code NOT IN (SELECT flight.airline_code FROM flight WHERE flight.from_airport = 'JFK' OR flight.to_airport = 'JFK' OR flight.stops > 0)
 
 "
-Which airlines do not have any flights that depart or arrive at JFK or do not have stopovers?,"SELECT DISTINCT {airline.airline_name, airline.airline_code} FROM airline WHERE airline.airline_code NOT IN (SELECT flight.airline_code FROM flight WHERE flight.from_airport = 'JFK' OR flight.to_airport = 'JFK' OR flight.stops > 0);",atis,table_join,"EXAMPLE QUESTION 1: Which airlines offer flights with a stopover in Dallas?
+Which airlines do not have any flights that either depart from/arrive at JFK, or have one or more stops?,"SELECT DISTINCT {airline.airline_name, airline.airline_code} FROM airline WHERE airline.airline_code NOT IN (SELECT flight.airline_code FROM flight WHERE flight.from_airport = 'JFK' OR flight.to_airport = 'JFK' OR flight.stops > 0);",atis,table_join,"EXAMPLE QUESTION 1: Which airlines offer flights with a stopover in Dallas?
 EXAMPLE QUERY 1: SELECT DISTINCT airline.airline_name FROM flight_stop JOIN airport ON flight_stop.stop_airport = airport.airport_code JOIN flight ON flight_stop.flight_id = flight.flight_id JOIN airline ON flight.airline_code = airline.airline_code WHERE airport.airport_location ILIKE '%Dallas%'
 
 EXAMPLE QUESTION 2: Which airlines offer flights from LAX to ORD?

--- a/data/questions_gen_snowflake.csv
+++ b/data/questions_gen_snowflake.csv
@@ -566,7 +566,7 @@ EXAMPLE QUESTION 2: Which flights operate on Mondays and Wednesdays? Give me the
 EXAMPLE QUERY 2: SELECT flight.flight_number FROM flight WHERE LOWER(flight.flight_days) LIKE '%mon%' AND LOWER(flight.flight_days) LIKE '%wed%'
 
 "
-Which airlines offer flights with a stopover in Dallas?,"SELECT DISTINCT {airline.airline_name, airline.airline_code} FROM flight_stop JOIN airport ON flight_stop.stop_airport = airport.airport_code JOIN flight ON flight_stop.flight_id = flight.flight_id JOIN airline ON flight.airline_code = airline.airline_code WHERE airport.airport_location ILIKE '%Dallas%';",atis,table_join,"EXAMPLE QUESTION 1: Which airlines do not have any flights that depart or arrive at JFK or do not have stopovers?
+Which airlines offer flights with a stopover in Dallas?,"SELECT DISTINCT {airline.airline_name, airline.airline_code} FROM flight_stop JOIN airport ON flight_stop.stop_airport = airport.airport_code JOIN flight ON flight_stop.flight_id = flight.flight_id JOIN airline ON flight.airline_code = airline.airline_code WHERE airport.airport_location ILIKE '%Dallas%';",atis,table_join,"EXAMPLE QUESTION 1: Which airlines do not have any flights that either depart from/arrive at JFK, or have one or more stops?
 EXAMPLE QUERY 1: SELECT DISTINCT airline.airline_name FROM airline WHERE airline.airline_code NOT IN (SELECT flight.airline_code FROM flight WHERE flight.from_airport = 'JFK' OR flight.to_airport = 'JFK' OR flight.stops > 0)
 
 EXAMPLE QUESTION 2: Which airlines offer flights from LAX to ORD?
@@ -583,11 +583,11 @@ EXAMPLE QUERY 2: SELECT airline.airline_name, flight.stops FROM flight JOIN airl
 "Which airlines offer flights from Chicago (ORD) to New York (JFK), and how many stops do they have, sorted by number of stops in ascending order?","SELECT {airline.airline_name, airline.airline_code}, flight.stops FROM flight JOIN airline ON flight.airline_code = airline.airline_code WHERE flight.from_airport = 'ORD' AND flight.to_airport = 'JFK' GROUP BY {}, flight.stops ORDER BY flight.stops NULLS LAST;",atis,table_join,"EXAMPLE QUESTION 1: Which airlines offer flights from LAX to ORD?
 EXAMPLE QUERY 1: SELECT DISTINCT airline.airline_name FROM flight JOIN airline ON flight.airline_code = airline.airline_code WHERE flight.from_airport = 'LAX' AND flight.to_airport = 'ORD'
 
-EXAMPLE QUESTION 2: Which airlines do not have any flights that depart or arrive at JFK or do not have stopovers?
+EXAMPLE QUESTION 2: Which airlines do not have any flights that either depart from/arrive at JFK, or have one or more stops?
 EXAMPLE QUERY 2: SELECT DISTINCT airline.airline_name FROM airline WHERE airline.airline_code NOT IN (SELECT flight.airline_code FROM flight WHERE flight.from_airport = 'JFK' OR flight.to_airport = 'JFK' OR flight.stops > 0)
 
 "
-Which airlines do not have any flights that depart or arrive at JFK or do not have stopovers?,"SELECT DISTINCT {airline.airline_name, airline.airline_code} FROM airline WHERE airline.airline_code NOT IN (SELECT flight.airline_code FROM flight WHERE flight.from_airport = 'JFK' OR flight.to_airport = 'JFK' OR flight.stops > 0);",atis,table_join,"EXAMPLE QUESTION 1: Which airlines offer flights with a stopover in Dallas?
+Which airlines do not have any flights that either depart from/arrive at JFK, or have one or more stops?,"SELECT DISTINCT {airline.airline_name, airline.airline_code} FROM airline WHERE airline.airline_code NOT IN (SELECT flight.airline_code FROM flight WHERE flight.from_airport = 'JFK' OR flight.to_airport = 'JFK' OR flight.stops > 0);",atis,table_join,"EXAMPLE QUESTION 1: Which airlines offer flights with a stopover in Dallas?
 EXAMPLE QUERY 1: SELECT DISTINCT airline.airline_name FROM flight_stop JOIN airport ON flight_stop.stop_airport = airport.airport_code JOIN flight ON flight_stop.flight_id = flight.flight_id JOIN airline ON flight.airline_code = airline.airline_code WHERE airport.airport_location ILIKE '%Dallas%'
 
 EXAMPLE QUESTION 2: Which airlines offer flights from LAX to ORD?

--- a/eval/eval.py
+++ b/eval/eval.py
@@ -40,18 +40,22 @@ def normalize_table(
     else:
         # extract unsorted/pre-sorted columns by checking each series under each column
         unsorted_cols = []
-        presorted_cols = [] # likely the ORDER BY column(s) pre-sorted by the query
+        presorted_cols = []  # likely the ORDER BY column(s) pre-sorted by the query
         for col in sorted_df.columns:
             if not sorted_df[col].equals(sorted_df[col].sort_values()):
                 unsorted_cols.append(col)
             else:
                 presorted_cols.append(col)
-        
-        sorting_order = presorted_cols + unsorted_cols # prioritize sorting by pre-sorted columns first
+
+        sorting_order = (
+            presorted_cols + unsorted_cols
+        )  # prioritize sorting by pre-sorted columns first
         # pre-sorted columns should be non-zero if has_order_by is True
-        if len(presorted_cols) > 0: 
-            sorted_df = sorted_df.sort_values(by=sorting_order) # sort rows using sorting_order
-        
+        if len(presorted_cols) > 0:
+            sorted_df = sorted_df.sort_values(
+                by=sorting_order
+            )  # sort rows using sorting_order
+
     # reset index
     sorted_df = sorted_df.reset_index(drop=True)
     return sorted_df

--- a/eval/eval.py
+++ b/eval/eval.py
@@ -25,7 +25,7 @@ def normalize_table(
     # remove duplicate rows, if any
     df = df.drop_duplicates()
 
-    # sort columns in alphabetical order
+    # sort columns in alphabetical order of column names
     sorted_df = df.reindex(sorted(df.columns), axis=1)
 
     # check if query_category is 'order_by' and if question asks for ordering
@@ -37,6 +37,21 @@ def normalize_table(
     if not has_order_by:
         # sort rows using values from first column to last
         sorted_df = sorted_df.sort_values(by=list(sorted_df.columns))
+    else:
+        # extract unsorted/pre-sorted columns by checking each series under each column
+        unsorted_cols = []
+        presorted_cols = [] # likely the ORDER BY column(s) pre-sorted by the query
+        for col in sorted_df.columns:
+            if not sorted_df[col].equals(sorted_df[col].sort_values()):
+                unsorted_cols.append(col)
+            else:
+                presorted_cols.append(col)
+        
+        sorting_order = presorted_cols + unsorted_cols # prioritize sorting by pre-sorted columns first
+        # pre-sorted columns should be non-zero if has_order_by is True
+        if len(presorted_cols) > 0: 
+            sorted_df = sorted_df.sort_values(by=sorting_order) # sort rows using sorting_order
+        
     # reset index
     sorted_df = sorted_df.reset_index(drop=True)
     return sorted_df

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -33,6 +33,7 @@ def test_dataframes():
     df0 = pd.DataFrame({"A": [], "B": []})
     df0_same = pd.DataFrame({"A": [], "B": []})
     df1 = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
+    df2 = pd.DataFrame({"A": [1, 2, 3, 4], "B": [4, 5, 5, 6]})
     df1_same = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
     df1_value_diff = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 7]})
     df1_columns_reordered = pd.DataFrame({"B": [4, 5, 6], "A": [1, 2, 3]})
@@ -43,10 +44,20 @@ def test_dataframes():
     df1_rows_reordered_more_cols = pd.DataFrame(
         {"X": [2, 1, 3], "Y": [5, 4, 6], "Z": [7, 8, 9]}
     )
+    df2_rows_reordered = pd.DataFrame({"A": [2, 1, 4, 3], "B": [5, 4, 6, 5]})
+    df2_rows_reordered_sortb = pd.DataFrame({"A": [1, 3, 2, 4], "B": [4, 5, 5, 6]})
+    df2_rows_reordered_sortb_renamed = pd.DataFrame(
+        {"X": [1, 3, 2, 4], "Y": [4, 5, 5, 6]}
+    )
+    df2_rows_reordered_sortb_more_cols = pd.DataFrame(
+        {"X": [1, 3, 2, 4], "Y": [4, 5, 5, 6], "Z": ["e", "b", "c", "d"]}
+    )
+
     return (
         df0,
         df0_same,
         df1,
+        df2,
         df1_same,
         df1_value_diff,
         df1_columns_reordered,
@@ -55,6 +66,10 @@ def test_dataframes():
         df1_rows_reordered,
         df1_rows_reordered_columns_renamed,
         df1_rows_reordered_more_cols,
+        df2_rows_reordered,
+        df2_rows_reordered_sortb,
+        df2_rows_reordered_sortb_renamed,
+        df2_rows_reordered_sortb_more_cols,
     )
 
 
@@ -67,7 +82,7 @@ def test_normalize_table_no_order_by(unordered_dataframe):
             "name": ["John", "Jane", "Alice"],
         }
     )
-    question = "What is the average age of the people in the table?"
+    question = "What are the ages of the people in the table?"
     normalized_df = normalize_table(unordered_dataframe, query, question)
     assert_frame_equal(expected_df, normalized_df)
 
@@ -81,7 +96,7 @@ def test_normalize_table_with_order_by(unordered_dataframe):
             "name": ["John", "Jane", "Alice"],
         }
     )
-    question_sort = "What is the average age of the people in the table? sort by name."
+    question_sort = "What are the ages of the people in the table? Sort by age."
     normalized_df = normalize_table(unordered_dataframe, query_order_by, question_sort)
 
     assert_frame_equal(expected_df, normalized_df)
@@ -210,6 +225,7 @@ def test_compare_df(test_dataframes):
         df0,
         df0_same,
         df1,
+        df2,
         df1_same,
         df1_value_diff,
         df1_columns_reordered,
@@ -218,10 +234,14 @@ def test_compare_df(test_dataframes):
         df1_rows_reordered,
         df1_rows_reordered_columns_renamed,
         df1_rows_reordered_more_cols,
+        df2_rows_reordered,
+        df2_rows_reordered_sortb,
+        df2_rows_reordered_sortb_renamed,
+        df2_rows_reordered_sortb_more_cols,
     ) = test_dataframes
 
-    question = "What is the average age of the people in the table?"
-    question_sort = "What is the average age of the people in the table? sort by name."
+    question = "Here is a random question"
+    question_sort = "Here is a random question that has a sort by instruction."
 
     # Test case 1: Empty DataFrames, expect True
     assert compare_df(df0, df0_same, query, question) == True
@@ -255,6 +275,31 @@ def test_compare_df(test_dataframes):
     # Test case 10: Reordered Rows with specific ordering and renamed and additional columns, expect False
     assert (compare_df(df1, df1_rows_reordered_more_cols, query, question)) == False
 
+    # Test case 11: Reordered rows, expect True
+    assert compare_df(df2, df2_rows_reordered, query, question) == True
+
+    # Test case 12: Reordered rows with specific ordering, expect False
+    assert compare_df(df2, df2_rows_reordered, query_order_by, question_sort) == False
+
+    # Test case 13: Reordered rows with specific asc ordering in col B, expect True
+    assert (
+        compare_df(df2, df2_rows_reordered_sortb, query_order_by, question_sort) == True
+    )
+
+    # Test case 14: Reordered rows with specific asc ordering in col B and renamed columns, expect True
+    assert (
+        compare_df(df2, df2_rows_reordered_sortb_renamed, query_order_by, question_sort)
+        == True
+    )
+
+    # Test case 15: Reordered rows with specific asc ordering in col B and renamed and additional columns, expect False
+    assert (
+        compare_df(
+            df2, df2_rows_reordered_sortb_more_cols, query_order_by, question_sort
+        )
+        == False
+    )
+
 
 def test_subset_df(test_dataframes):
     # Assigning the test_dataframes fixture to individual variables
@@ -262,6 +307,7 @@ def test_subset_df(test_dataframes):
         df0,
         df0_same,
         df1,
+        df2,
         df1_same,
         df1_value_diff,
         df1_columns_reordered,
@@ -270,10 +316,14 @@ def test_subset_df(test_dataframes):
         df1_rows_reordered,
         df1_rows_reordered_columns_renamed,
         df1_rows_reordered_more_cols,
+        df2_rows_reordered,
+        df2_rows_reordered_sortb,
+        df2_rows_reordered_sortb_renamed,
+        df2_rows_reordered_sortb_more_cols,
     ) = test_dataframes
 
-    question = "What is the average age of the people in the table?"
-    question_sort = "What is the average age of the people in the table? sort by name."
+    question = "Here is a random question"
+    question_sort = "Here is a random question that has a sort by instruction."
 
     # Test case 1: Empty DataFrames, expect False
     assert subset_df(df0, df0_same, query, question) == False
@@ -304,6 +354,31 @@ def test_subset_df(test_dataframes):
 
     # Test case 10: Reordered Rows with specific ordering and renamed and additional columns, expect True
     assert (subset_df(df1, df1_rows_reordered_more_cols, query, question)) == True
+
+    # Test case 11: Reordered rows, expect True
+    assert subset_df(df2, df2_rows_reordered, query, question) == True
+
+    # Test case 12: Reordered rows with specific ordering, expect False
+    assert subset_df(df2, df2_rows_reordered, query_order_by, question_sort) == False
+
+    # Test case 13: Reordered rows with specific asc ordering in col B, expect True
+    assert (
+        subset_df(df2, df2_rows_reordered_sortb, query_order_by, question_sort) == True
+    )
+
+    # Test case 14: Reordered rows with specific asc ordering in col B and renamed columns, expect True
+    assert (
+        subset_df(df2, df2_rows_reordered_sortb_renamed, query_order_by, question_sort)
+        == True
+    )
+
+    # Test case 15: Reordered rows with specific asc ordering in col B and renamed and additional columns, expect True
+    assert (
+        subset_df(
+            df2, df2_rows_reordered_sortb_more_cols, query_order_by, question_sort
+        )
+        == True
+    )
 
 
 @mock.patch("eval.eval.query_postgres_db")


### PR DESCRIPTION
Previously, we found the logic of the `compare_df` function to fail at specific questions like the following:
```
# Q: How many publications were presented at each conference, ordered by the number of publications in descending order? Give the names of the conferences and their corresponding number of publications.

# df from gold query
name | num_publications 
------+------------------
 ICML |                3
 AAAS |                1
 ISA  |                1

# df from generated query
 name | num_publications 
------+-------------------
 ICML |                 3
 ISA  |                 1
 AAAS |                 1
```
The latter query should be considered correct since the question only requires the ordering of the `num_publications` column and not the `name` column. However, the `compare_df` function used to consider the latter query as incorrect. 
We have thus fixed this issue in the `normalize_table` function by first sorting rows by ORDER BY columns before sorting by the rest of the columns.

Mini note: We have also added a minor change by rephrasing a question in `questions_gen` to remove confusing double negatives.