### PR TITLE
Changes to sorting eval for increased robustness

### DIFF
--- a/eval/eval.py
+++ b/eval/eval.py
@@ -33,16 +33,17 @@ def normalize_table(
     in_question = re.search(pattern, question.lower())  # true if contains
     if query_category == "order_by" or in_question:
         has_order_by = True
-        
+
         if sql:
             # determine which columns are in the ORDER BY clause of the sql generated, using regex
             pattern = re.compile(r"ORDER BY[\s\S]*", re.IGNORECASE)
             order_by_clause = re.search(pattern, sql)
             if order_by_clause:
                 order_by_clause = order_by_clause.group(0)
-                # get all columns in the ORDER BY clause, by looking at the text between ORDER BY and the next semicolon, comma, or parantheses
-                pattern = re.compile(r"(?<=ORDER BY)(.*?)(?=;|,|\))", re.IGNORECASE)
+                # get all columns in the ORDER BY clause, by looking at the text between ORDER BY and the next semicolon, comma, or non-closing parenthesis
+                pattern = re.compile(r"ORDER BY[\s\S]*?(?=;|,|\))", re.IGNORECASE)
                 order_by_columns = re.findall(pattern, order_by_clause)[0].split()
+                order_by_columns = [col.split(".")[-1] for col in order_by_columns]
 
                 ascending = False
                 # if there is a DESC or ASC in the ORDER BY clause, set the ascending to that
@@ -50,21 +51,30 @@ def normalize_table(
                     ascending = False
                 elif "ASC" in [i.upper() for i in order_by_columns]:
                     ascending = True
-                
+
                 # remove whitespace and commas
                 order_by_columns = [col.strip() for col in order_by_columns]
                 order_by_columns = [col.replace(",", "") for col in order_by_columns]
-                order_by_columns = [i for i in order_by_columns if i.lower() not in ["desc", "asc", "nulls", "last", "first"]]
-                
-                # get all columns in sorted_df that are not in order_by_columns
-                other_columns = [i for i in sorted_df.columns.tolist() if i not in order_by_columns]
+                order_by_columns = [
+                    i
+                    for i in order_by_columns
+                    if i.lower()
+                    not in ["desc", "asc", "nulls", "last", "first", "limit"]
+                ]
 
-                sorted_df = sorted_df.sort_values(by=order_by_columns+other_columns, ascending=ascending)
-    
+                # get all columns in sorted_df that are not in order_by_columns
+                other_columns = [
+                    i for i in sorted_df.columns.tolist() if i not in order_by_columns
+                ]
+
+                sorted_df = sorted_df.sort_values(
+                    by=order_by_columns + other_columns, ascending=ascending
+                )
+
     if not has_order_by:
         # sort rows using values from first column to last
         sorted_df = sorted_df.sort_values(by=list(sorted_df.columns))
-    
+
     # reset index
     sorted_df = sorted_df.reset_index(drop=True)
     return sorted_df
@@ -202,8 +212,12 @@ def query_snowflake_db(
 
 
 def compare_df(
-    df1: pd.DataFrame, df2: pd.DataFrame, query_category: str, question: str,
-    query_gold: str, query_gen: str
+    df1: pd.DataFrame,
+    df2: pd.DataFrame,
+    query_category: str,
+    question: str,
+    query_gold: str,
+    query_gen: str,
 ) -> bool:
     """
     Compares two dataframes and returns True if they are the same, else False.
@@ -309,7 +323,9 @@ def compare_query_results(
             raise ValueError(
                 f"Invalid db_type: {db_type}. Only postgres and snowflake are supported."
             )
-        if compare_df(results_gold, results_gen, query_category, question, query_gold, query_gen):
+        if compare_df(
+            results_gold, results_gen, query_category, question, query_gold, query_gen
+        ):
             return (True, True)
         elif subset_df(results_gold, results_gen, query_category, question):
             correct = True

--- a/eval/eval.py
+++ b/eval/eval.py
@@ -224,8 +224,8 @@ def compare_df(
     df2: pd.DataFrame,
     query_category: str,
     question: str,
-    query_gold: str,
-    query_gen: str,
+    query_gold: str = None,
+    query_gen: str = None,
 ) -> bool:
     """
     Compares two dataframes and returns True if they are the same, else False.


### PR DESCRIPTION
Earlier, the model would not consider these two results identical if they were for an `ORDER BY` question.

```
 name | num_publications 
------+------------------
 ICML |                3
 AAAS |                1
 ISA  |                1
```

```
 name | publication_count 
------+-------------------
 ICML |                 3
 ISA  |                 1
 AAAS |                 1
```

This PR fixes this issue. To test

```python
from eval.eval import normalize_table
import pandas as pd

df1 = pd.DataFrame([["ICML", 3], ["AAAS", 1], ["ISA", 1]], columns=["name", "num_publications"])
df2 = pd.DataFrame([["ICML", 3], ["ISA", 1], ["AAAS", 1]], columns=["name", "publication_count"])

normalize_table(df1, "order_by", "", "SELECT conference.name, COUNT(publication.pid) AS num_publications FROM publication JOIN conference ON publication.cid=conference.cid GROUP BY conference.name, conference.cid ORDER BY num_publications DESC NULLS LAST;"

normalize_table(df2, "order_by", "", "SELECT c.name, COUNT(p.pid) AS publication_count FROM publication p JOIN conference c ON p.cid = c.cid GROUP BY c.name ORDER BY publication_count DESC;")

# the normalize_table function now handles these kinds of cases correct
```