### PR TITLE
Add llama_cpp_runner.py for Llama CPP evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,8 @@ python main.py \
   --upload_url <your cloud function url>
 ```
 
+If you would like to always report your results to an upload_url, even if it's not explicitly provided, you can set it in your environment variables as `SQL_EVAL_UPLOAD_URL`
+
 #### Testing the function locally
 If you'd like to modify the functions and test it out locally, you can run these sample commands to deploy the function locally and then trigger the openai runner:
 ```bash

--- a/README.md
+++ b/README.md
@@ -182,15 +182,12 @@ python -m vllm.entrypoints.api_server \
     --dtype float16
 
 # to run sql-eval using the api runner - depending on how much your GPUs can tahan, can increase p to higher values
-python main.py \
+python -W ignore main.py \
   -db postgres \
-  -o results/results.csv \
-  -g api \
-  -b 1 \
-  -f prompts/prompt.md \
-  --url localhost:8000/generate \
-  -p 5 \
-  -n 10
+  -o "results/results.csv" \
+  -g llama_cpp \
+  -f "prompts/prompt.md" \
+  -m path/to/model.gguf
 ```
 
 ### Multiple Prompts
@@ -221,6 +218,10 @@ python main.py \
   -n 10
 ```
 
+### Llama CPP
+```bash
+python
+
 ### CLI Flags
 You can use the following flags in the command line to change the configurations of your evaluation runs.
 | CLI Flags     | Description |
@@ -228,7 +229,7 @@ You can use the following flags in the command line to change the configurations
 |  -db, --db_type   |  Database type to run your queries on. Currently supported types are `postgres` and `snowflake`.   |
 |  -q, --questions_file   |  CSV file that contains the test questions and true queries. If this is not set, it will default to the relevant `questions_gen_<db_type>.csv` file. It may be helpful to always end your questions_file name with `_<db_type>.csv` to ensure compatibility between the queries and selected db_type.   |
 | -n, --num_questions  |  Use this to limit the total number of questions you want to test.  |
-|  -g, --model_type   |  Model type used. Make sure this matches the model used. Currently defined options in `main.py` are `oa` for OpenAI models, `anthropic` for Anthropic models, `hf` for Hugging Face models, and `api` for API endpoints.   |
+|  -g, --model_type   |  Model type used. Make sure this matches the model used. Currently defined options in `main.py` are `oa` for OpenAI models, `anthropic` for Anthropic models, `hf` for Hugging Face models, `api` for API endpoints, and `llama_cpp` for llama cpp.   |
 |  -m, --model   |  Model that will be tested and used to generate the queries. Currently defined options for OpenAI models are chat models `gpt-3.5-turbo-0613` and `gpt-4-0613`, and non-chat model `text-davinci-003`. Options for Anthropic are `claude-2` and `claude-instant-1`. For Hugging Face models, simply use the path of your chosen model (e.g. `defog/sqlcoder`).  |
 |  -a, --adapter   |  Path to the relevant adapter model you're using. Only available for the `hf_runner` |
 |  --api_url   |  The URL of the custom API you want to send the prompt to. Only used when model_type is `api` |

--- a/README.md
+++ b/README.md
@@ -181,13 +181,16 @@ python -m vllm.entrypoints.api_server \
     --tensor-parallel-size 4 \
     --dtype float16
 
-# to run sql-eval using the api runner - depending on how much your GPUs can tahan, can increase p to higher values
-python -W ignore main.py \
+# to run sql-eval using the api runner - depending on how much your GPUs can take, can increase p to higher values
+python main.py \
   -db postgres \
-  -o "results/results.csv" \
-  -g llama_cpp \
-  -f "prompts/prompt.md" \
-  -m path/to/model.gguf
+  -o results/results.csv \
+  -g api \
+  -b 1 \
+  -f prompts/prompt.md \
+  --url localhost:8000/generate \
+  -p 5 \
+  -n 10
 ```
 
 ### Multiple Prompts
@@ -219,8 +222,20 @@ python main.py \
 ```
 
 ### Llama CPP
+To run the eval using Llama CPP, you can use the following code. Before running this, you must install `llama-cpp-python` with the following (on Apple Silicon)
+
+`CMAKE_ARGS="-DLLAMA_METAL=on" pip install llama-cpp-python`
+
+Note that llama-cpp-python library does not currently have beam search, and hence will have lower quality results.
+
 ```bash
-python
+python -W ignore main.py \
+  -db postgres \
+  -o "results/results.csv" \
+  -g llama_cpp \
+  -f "prompts/prompt.md" \
+  -m path/to/model.gguf
+  ```
 
 ### CLI Flags
 You can use the following flags in the command line to change the configurations of your evaluation runs.

--- a/eval/llama_cpp_runner.py
+++ b/eval/llama_cpp_runner.py
@@ -151,7 +151,7 @@ def run_llama_cpp_eval(args):
             upload_results(
                 results=results,
                 url=args.upload_url,
-                runner_type="api_runner",
+                runner_type="llama_cpp_runner",
                 prompt=prompt,
                 args=args,
             )

--- a/eval/llama_cpp_runner.py
+++ b/eval/llama_cpp_runner.py
@@ -1,0 +1,149 @@
+import os
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+from eval.eval import compare_query_results
+import pandas as pd
+from utils.pruning import prune_metadata_str
+from utils.questions import prepare_questions_df
+from utils.creds import db_creds_all
+from tqdm import tqdm
+from time import time
+from utils.reporting import upload_results
+from llama_cpp import Llama
+
+def generate_prompt(
+    prompt_file, question, db_name, instructions="", k_shot_prompt="", public_data=True
+):
+    with open(prompt_file, "r") as f:
+        prompt = f.read()
+    question_instructions = question + " " + instructions
+
+    pruned_metadata_str = prune_metadata_str(
+        question_instructions, db_name, public_data
+    )
+    prompt = prompt.format(
+        user_question=question,
+        instructions=instructions,
+        table_metadata_string=pruned_metadata_str,
+        k_shot_prompt=k_shot_prompt,
+    )
+    return prompt
+
+
+def process_row(llm, row):
+    start_time = time()
+    prompt = row["prompt"]
+    generated_query = llm(
+        prompt,
+        max_tokens=512,
+        temperature=0,
+        top_p=1,
+        echo=False,
+        repeat_penalty=1.0
+    )["choices"][0]["text"].split(";")[0].split("```")[0].strip() + ";"
+    end_time = time()
+    row["generated_query"] = generated_query
+    row["latency_seconds"] = end_time - start_time
+    golden_query = row["query"]
+    db_name = row["db_name"]
+    db_type = row["db_type"]
+    question = row["question"]
+    query_category = row["query_category"]
+    exact_match = correct = 0
+
+    try:
+        exact_match, correct = compare_query_results(
+            query_gold=golden_query,
+            query_gen=generated_query,
+            db_name=db_name,
+            db_type=db_type,
+            db_creds=db_creds_all[row["db_type"]],
+            question=question,
+            query_category=query_category,
+        )
+        row["exact_match"] = int(exact_match)
+        row["correct"] = int(correct)
+        row["error_msg"] = ""
+    except Exception as e:
+        row["error_db_exec"] = 1
+        row["error_msg"] = f"QUERY EXECUTION ERROR: {e}"
+    return row
+
+def run_llama_cpp_eval(args):
+    # get params from args
+    questions_file = args.questions_file
+    prompt_file_list = args.prompt_file
+    num_questions = args.num_questions
+    public_data = not args.use_private_data
+    model_path = args.model
+    output_file_list = args.output_file
+    k_shot = args.k_shot
+    max_workers = args.parallel_threads
+    db_type = args.db_type
+
+    llm = Llama(model_path=model_path, n_gpu_layers=1, n_ctx=2048)
+
+    # get questions
+    print("Preparing questions...")
+    print(
+        f"Using {'all' if num_questions is None else num_questions} question(s) from {questions_file}"
+    )
+    df = prepare_questions_df(questions_file, db_type, num_questions, k_shot)
+
+    for prompt_file, output_file in zip(prompt_file_list, output_file_list):
+        # create a prompt for each question
+        df["prompt"] = df[
+            ["question", "db_name", "instructions", "k_shot_prompt"]
+        ].apply(
+            lambda row: generate_prompt(
+                prompt_file,
+                row["question"],
+                row["db_name"],
+                row["instructions"],
+                row["k_shot_prompt"],
+                public_data,
+            ),
+            axis=1,
+        )
+
+        total_tried = 0
+        total_correct = 0
+        output_rows = []
+
+        with tqdm(total=len(df)) as pbar:
+            for row in df.to_dict("records"):
+                row = process_row(llm, row)
+                output_rows.append(row)
+                if row["correct"]:
+                    total_correct += 1
+                total_tried += 1
+                pbar.update(1)
+                pbar.set_description(
+                    f"Correct so far: {total_correct}/{total_tried} ({100*total_correct/total_tried:.2f}%)"
+                )
+
+        output_df = pd.DataFrame(output_rows)
+        del output_df["prompt"]
+        print(output_df.groupby("query_category")[["exact_match", "correct"]].mean())
+        output_df = output_df.sort_values(by=["db_name", "query_category", "question"])
+        # get directory of output_file and create if not exist
+        output_dir = os.path.dirname(output_file)
+        if not os.path.exists(output_dir):
+            os.makedirs(output_dir)
+        try:
+            output_df.to_csv(output_file, index=False, float_format="%.2f")
+        except:
+            output_df.to_pickle(output_file)
+
+        results = output_df.to_dict("records")
+        # upload results
+        with open(prompt_file, "r") as f:
+            prompt = f.read()
+        if args.upload_url is not None:
+            upload_results(
+                results=results,
+                url=args.upload_url,
+                runner_type="api_runner",
+                prompt=prompt,
+                args=args,
+            )

--- a/eval/llama_cpp_runner.py
+++ b/eval/llama_cpp_runner.py
@@ -89,7 +89,7 @@ def run_llama_cpp_eval(args):
     max_workers = args.parallel_threads
     db_type = args.db_type
 
-    llm = Llama(model_path=model_path, n_gpu_layers=1, n_ctx=2048)
+    llm = Llama(model_path=model_path, n_gpu_layers=-1, n_ctx=2048)
 
     # get questions
     print("Preparing questions...")

--- a/eval/llama_cpp_runner.py
+++ b/eval/llama_cpp_runner.py
@@ -11,6 +11,7 @@ from time import time
 from utils.reporting import upload_results
 from llama_cpp import Llama
 
+
 def generate_prompt(
     prompt_file, question, db_name, instructions="", k_shot_prompt="", public_data=True
 ):
@@ -33,14 +34,20 @@ def generate_prompt(
 def process_row(llm, row):
     start_time = time()
     prompt = row["prompt"]
-    generated_query = llm(
-        prompt,
-        max_tokens=512,
-        temperature=0,
-        top_p=1,
-        echo=False,
-        repeat_penalty=1.0
-    )["choices"][0]["text"].split(";")[0].split("```")[0].strip() + ";"
+    generated_query = (
+        llm(
+            prompt,
+            max_tokens=512,
+            temperature=0,
+            top_p=1,
+            echo=False,
+            repeat_penalty=1.0,
+        )["choices"][0]["text"]
+        .split(";")[0]
+        .split("```")[0]
+        .strip()
+        + ";"
+    )
     end_time = time()
     row["generated_query"] = generated_query
     row["latency_seconds"] = end_time - start_time
@@ -68,6 +75,7 @@ def process_row(llm, row):
         row["error_db_exec"] = 1
         row["error_msg"] = f"QUERY EXECUTION ERROR: {e}"
     return row
+
 
 def run_llama_cpp_eval(args):
     # get params from args

--- a/main.py
+++ b/main.py
@@ -74,6 +74,7 @@ if __name__ == "__main__":
         run_api_eval(args)
     elif args.model_type == "llama_cpp":
         from eval.llama_cpp_runner import run_llama_cpp_eval
+
         run_llama_cpp_eval(args)
     else:
         raise ValueError(

--- a/main.py
+++ b/main.py
@@ -72,6 +72,9 @@ if __name__ == "__main__":
         from eval.api_runner import run_api_eval
 
         run_api_eval(args)
+    elif args.model_type == "llama_cpp":
+        from eval.llama_cpp_runner import run_llama_cpp_eval
+        run_llama_cpp_eval(args)
     else:
         raise ValueError(
             f"Invalid model type: {args.model_type}. Model type must be one of: 'oa', 'hf', 'anthropic', 'vllm', 'api'"

--- a/main.py
+++ b/main.py
@@ -1,4 +1,5 @@
 import argparse
+import os
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
@@ -35,6 +36,9 @@ if __name__ == "__main__":
         print(
             f"WARNING: Check that questions_file {args.questions_file} is compatible with db_type {args.db_type}"
         )
+
+    if args.upload_url is None:
+        args.upload_url = os.environ.get("SQL_EVAL_UPLOAD_URL")
 
     # check that the list of prompt files has the same length as the list of output files
     if len(args.prompt_file) != len(args.output_file):


### PR DESCRIPTION
We can now use `llama-cpp` and `llama-cpp-python` to run sql-eval.

To test with a q5 quant of `sqlcoder-7b-2`

```bash
python -W ignore main.py \
  -db postgres \
  -o "results/results.csv" \
  -g llama_cpp \
  -f "prompts/prompt.md" \
  -m ~/.defog/sqlcoder-7b-q5_k_m.gguf
```

Additionally, if you would like to always report your results to an upload_url, even if it's not explicitly provided, you can now set it in your environment variables as `SQL_EVAL_UPLOAD_URL`