### PR TITLE
Add number of columns and shuffle as args

### DIFF
--- a/eval/anthropic_runner.py
+++ b/eval/anthropic_runner.py
@@ -22,8 +22,6 @@ def run_anthropic_eval(args):
         args.questions_file, args.db_type, args.num_questions, args.k_shot
     )
     for prompt_file, output_file in zip(args.prompt_file, args.output_file):
-        qg_class = AnthropicQueryGenerator
-
         input_rows = question_query_df.to_dict("records")
         output_rows = []
         with ThreadPoolExecutor(args.parallel_threads) as executor:
@@ -34,7 +32,7 @@ def run_anthropic_eval(args):
                 db_name = row["db_name"]
                 db_creds = db_creds_all[row["db_type"]]
 
-                qg = qg_class(
+                qg = AnthropicQueryGenerator(
                     db_creds=copy.deepcopy(db_creds),
                     db_name=db_name,
                     model=args.model,
@@ -42,12 +40,6 @@ def run_anthropic_eval(args):
                     timeout=args.timeout_gen,
                     use_public_data=not args.use_private_data,
                     verbose=args.verbose,
-                    instructions=row["instructions"],
-                    k_shot_prompt=row["k_shot_prompt"],
-                    glossary=row["glossary"],
-                    table_metadata_string=row["table_metadata_string"],
-                    prev_invalid_sql=row["prev_invalid_sql"],
-                    prev_error_msg=row["prev_error_msg"],
                 )
 
                 generated_query_fut = executor.submit(
@@ -59,6 +51,8 @@ def run_anthropic_eval(args):
                     table_metadata_string=row["table_metadata_string"],
                     prev_invalid_sql=row["prev_invalid_sql"],
                     prev_error_msg=row["prev_error_msg"],
+                    columns_to_keep=args.num_columns,
+                    shuffle=args.shuffle_metadata,
                 )
                 futures.append(generated_query_fut)
 

--- a/eval/api_runner.py
+++ b/eval/api_runner.py
@@ -115,6 +115,8 @@ def run_api_eval(args):
                 row["prev_invalid_sql"],
                 row["prev_error_msg"],
                 public_data,
+                args.num_columns,
+                args.shuffle_metadata,
             ),
             axis=1,
         )

--- a/eval/hf_runner.py
+++ b/eval/hf_runner.py
@@ -146,6 +146,8 @@ def run_hf_eval(args):
                 row["prev_invalid_sql"],
                 row["prev_error_msg"],
                 public_data,
+                args.num_columns,
+                args.shuffle_metadata,
             ),
             axis=1,
         )

--- a/eval/llama_cpp_runner.py
+++ b/eval/llama_cpp_runner.py
@@ -104,6 +104,8 @@ def run_llama_cpp_eval(args):
                 row["prev_invalid_sql"],
                 row["prev_error_msg"],
                 public_data,
+                args.num_columns,
+                args.shuffle_metadata,
             ),
             axis=1,
         )

--- a/eval/mlx_runner.py
+++ b/eval/mlx_runner.py
@@ -97,6 +97,8 @@ def run_mlx_eval(args):
                 row["prev_invalid_sql"],
                 row["prev_error_msg"],
                 public_data,
+                args.num_columns,
+                args.shuffle_metadata,
             ),
             axis=1,
         )

--- a/eval/openai_runner.py
+++ b/eval/openai_runner.py
@@ -41,12 +41,6 @@ def run_openai_eval(args):
                     timeout=args.timeout_gen,
                     use_public_data=not args.use_private_data,
                     verbose=args.verbose,
-                    instructions=row["instructions"],
-                    k_shot_prompt=row["k_shot_prompt"],
-                    glossary=row["glossary"],
-                    table_metadata_string=row["table_metadata_string"],
-                    prev_invalid_sql=row["prev_invalid_sql"],
-                    prev_error_msg=row["prev_error_msg"],
                 )
 
                 generated_query_fut = executor.submit(
@@ -58,6 +52,8 @@ def run_openai_eval(args):
                     table_metadata_string=row["table_metadata_string"],
                     prev_invalid_sql=row["prev_invalid_sql"],
                     prev_error_msg=row["prev_error_msg"],
+                    columns_to_keep=args.num_columns,
+                    shuffle=args.shuffle_metadata,
                 )
                 futures.append(generated_query_fut)
 

--- a/eval/vllm_runner.py
+++ b/eval/vllm_runner.py
@@ -79,6 +79,8 @@ def run_vllm_eval(args):
                 row["prev_invalid_sql"],
                 row["prev_error_msg"],
                 public_data,
+                args.num_columns,
+                args.shuffle_metadata,
             ),
             axis=1,
         )

--- a/main.py
+++ b/main.py
@@ -3,18 +3,23 @@ import os
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
+    # data-related parameters
     parser.add_argument("-q", "--questions_file", type=str)
     parser.add_argument("-n", "--num_questions", type=int, default=None)
     parser.add_argument("-db", "--db_type", type=str, required=True)
+    parser.add_argument("-d", "--use_private_data", action="store_true")
+    # model-related parameters
     parser.add_argument("-g", "--model_type", type=str, required=True)
     parser.add_argument("-m", "--model", type=str)
     parser.add_argument("-a", "--adapter", type=str)
     parser.add_argument("--api_url", type=str)
-    parser.add_argument("-b", "--num_beams", type=int, default=4)
-    # take in a list of prompt files
+    # inference-technique-related parameters
     parser.add_argument("-f", "--prompt_file", nargs="+", type=str, required=True)
-    parser.add_argument("-d", "--use_private_data", action="store_true")
+    parser.add_argument("-b", "--num_beams", type=int, default=4)
+    parser.add_argument("-c", "--num_columns", type=int, default=20)
+    parser.add_argument("-s", "--shuffle_metadata", action="store_true")
     parser.add_argument("-k", "--k_shot", action="store_true")
+    # execution-related parameters
     parser.add_argument("-o", "--output_file", nargs="+", type=str, required=True)
     parser.add_argument("-p", "--parallel_threads", type=int, default=5)
     parser.add_argument("-t", "--timeout_gen", type=float, default=30.0)

--- a/query_generators/anthropic.py
+++ b/query_generators/anthropic.py
@@ -86,6 +86,8 @@ class AnthropicQueryGenerator(QueryGenerator):
         table_metadata_string: str,
         prev_invalid_sql: str,
         prev_error_msg: str,
+        columns_to_keep: int,
+        shuffle: bool,
     ) -> dict:
         start_time = time.time()
         self.err = ""
@@ -97,7 +99,11 @@ class AnthropicQueryGenerator(QueryGenerator):
         question_instructions = question + " " + instructions
         if table_metadata_string == "":
             pruned_metadata_str = prune_metadata_str(
-                question_instructions, self.db_name, self.use_public_data
+                question_instructions,
+                self.db_name,
+                self.use_public_data,
+                columns_to_keep,
+                shuffle,
             )
         else:
             pruned_metadata_str = table_metadata_string

--- a/query_generators/openai.py
+++ b/query_generators/openai.py
@@ -118,6 +118,8 @@ class OpenAIQueryGenerator(QueryGenerator):
         table_metadata_string: str,
         prev_invalid_sql: str,
         prev_error_msg: str,
+        columns_to_keep: int,
+        shuffle: bool,
     ) -> dict:
         start_time = time.time()
         self.err = ""
@@ -129,7 +131,11 @@ class OpenAIQueryGenerator(QueryGenerator):
         question_instructions = question + " " + instructions
         if table_metadata_string == "":
             pruned_metadata_str = prune_metadata_str(
-                question_instructions, self.db_name, self.use_public_data
+                question_instructions,
+                self.db_name,
+                self.use_public_data,
+                columns_to_keep,
+                shuffle,
             )
         else:
             pruned_metadata_str = table_metadata_string

--- a/utils/gen_prompt.py
+++ b/utils/gen_prompt.py
@@ -12,6 +12,8 @@ def generate_prompt(
     prev_invalid_sql="",
     prev_error_msg="",
     public_data=True,
+    columns_to_keep=20,
+    shuffle=True,
 ):
     with open(prompt_file, "r") as f:
         prompt = f.read()
@@ -19,7 +21,7 @@ def generate_prompt(
 
     if table_metadata_string == "":
         pruned_metadata_str = prune_metadata_str(
-            question_instructions, db_name, public_data
+            question_instructions, db_name, public_data, columns_to_keep, shuffle
         )
     else:
         pruned_metadata_str = table_metadata_string


### PR DESCRIPTION
Added number of columns being pruned from metadata as an argument, alongside whether or not we want to shuffle the metadata.
Added a unit test for the new behaviour.

Tested on openai's gpt3.5/4, claude-3-opus, mistral-mediumm, gemini-pro, and api server and the results are meaningful.