### PR TITLE
handle exceptions when comparing dataframes with single value

### DIFF
--- a/eval/eval.py
+++ b/eval/eval.py
@@ -235,16 +235,26 @@ def compare_df(
     query_gold and query_gen are the original queries that generated the respective dataframes.
     """
     # drop duplicates to ensure equivalence
-    if df_gold.shape == df_gen.shape and (df_gold.values == df_gen.values).all():
-        return True
+    try:
+        if df_gold.shape == df_gen.shape and (df_gold.values == df_gen.values).all():
+            return True
+    except:
+        if df_gold.shape == df_gen.shape and (df_gold.values == df_gen.values):
+            return True
 
     df_gold = normalize_table(df_gold, query_category, question, query_gold)
     df_gen = normalize_table(df_gen, query_category, question, query_gen)
 
-    if df_gold.shape == df_gen.shape and (df_gold.values == df_gen.values).all():
-        return True
-    else:
-        return False
+    try:
+        if df_gold.shape == df_gen.shape and (df_gold.values == df_gen.values).all():
+            return True
+        else:
+            return False
+    except:
+        if df_gold.shape == df_gen.shape and (df_gold.values == df_gen.values):
+            return True
+        else:
+            return False
 
 
 def subset_df(


### PR DESCRIPTION
Previously, the question `What's the average duration between departure and arrival times minus 34 minutes? Convert from UNIX to regular datetime.`, we always got a `'bool' object has no attribute 'all'` error

Using the traceback, it seems like the error was coming from this section of the code:

```
Traceback (most recent call last):
  File "/Users/rishabh/defog/sql-eval/eval/api_runner.py", line 54, in process_row
    exact_match, correct = compare_query_results(
  File "/Users/rishabh/defog/sql-eval/eval/eval.py", line 348, in compare_query_results
    if compare_df(
  File "/Users/rishabh/defog/sql-eval/eval/eval.py", line 250, in compare_df
    if df_gold.shape == df_gen.shape and (df_gold.values == df_gen.values).all():
AttributeError: 'bool' object has no attribute 'all'
```

This fixes this with better exception handling