### PR TITLE
Enable argument for specifying how much to round floats to

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ When testing your own query generator with an existing runner, you can replace t
 
 ## Running the Test
 
-### OpenAI / Anthropic
+### OpenAI
 Remember to have your API key (`OPENAI_API_KEY` or `ANTHROPIC_API_KEY`) set as an environment variable before running the test if you plan to call the OpenAI or Anthropic/other LLM API's accordingly.
 
 To test it out with just 10 questions (instead of all 200), parallelized across 5 :
@@ -134,6 +134,7 @@ python main.py \
   -p 5
 ```
 
+### Anthropic
 To test out the full suite of questions for claude-3:
 ```bash
 python main.py \

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ python main.py \
   -p 5
 ```
 
-To test out the full suite of questions for claude-2:
+To test out the full suite of questions for claude-3:
 ```bash
 python main.py \
   -db postgres \

--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ You can use the following flags in the command line to change the configurations
 | -n, --num_questions | Use this to limit the total number of questions you want to test.                                                                                                                                                                                           |
 | -db, --db_type       | Database type to run your queries on. Currently supported types are `postgres` and `snowflake`.                                                                                                                                                             |
 | -d, --use_private_data | Use this to read from your own private data library.                                                                                                                                                                                                        |
+| -dp, --decimal_points | Use this to specify the number of decimal points a result should be rounded to. This is `None` by default                                                                                                                                                                                                        |
 
 ### Model-related parameters
 

--- a/eval/anthropic_runner.py
+++ b/eval/anthropic_runner.py
@@ -104,6 +104,7 @@ def run_anthropic_eval(args):
                             question=question,
                             query_category=query_category,
                             table_metadata_string=table_metadata_string,
+                            decimal_points=args.decimal_points,
                         )
                         row["exact_match"] = int(exact_match)
                         row["correct"] = int(correct)

--- a/eval/api_runner.py
+++ b/eval/api_runner.py
@@ -143,7 +143,9 @@ def run_api_eval(args):
         with ThreadPoolExecutor(max_workers=max_workers) as executor:
             futures = []
             for row in df.to_dict("records"):
-                futures.append(executor.submit(process_row, row, api_url, num_beams, args))
+                futures.append(
+                    executor.submit(process_row, row, api_url, num_beams, args)
+                )
 
             with tqdm(as_completed(futures), total=len(futures)) as pbar:
                 for f in pbar:

--- a/eval/api_runner.py
+++ b/eval/api_runner.py
@@ -17,7 +17,7 @@ from utils.reporting import upload_results
 tokenizer = AutoTokenizer.from_pretrained("codellama/CodeLlama-7b-hf")
 
 
-def process_row(row, api_url, num_beams):
+def process_row(row, api_url, num_beams, args):
     start_time = time()
     r = requests.post(
         api_url,
@@ -65,6 +65,7 @@ def process_row(row, api_url, num_beams):
             question=question,
             query_category=query_category,
             table_metadata_string=table_metadata_string,
+            decimal_points=args.decimal_points,
         )
         row["exact_match"] = int(exact_match)
         row["correct"] = int(correct)
@@ -142,7 +143,7 @@ def run_api_eval(args):
         with ThreadPoolExecutor(max_workers=max_workers) as executor:
             futures = []
             for row in df.to_dict("records"):
-                futures.append(executor.submit(process_row, row, api_url, num_beams))
+                futures.append(executor.submit(process_row, row, api_url, num_beams, args))
 
             with tqdm(as_completed(futures), total=len(futures)) as pbar:
                 for f in pbar:

--- a/eval/eval.py
+++ b/eval/eval.py
@@ -157,7 +157,7 @@ def get_all_minimal_queries(query: str) -> "list[str]":
 
 
 def query_postgres_db(
-    query: str, db_name: str, db_creds: dict = None, timeout: float = 10.0
+    query: str, db_name: str, db_creds: dict = None, timeout: float = 10.0, decimal_points: int = None
 ) -> pd.DataFrame:
     """
     Runs query on postgres db and returns results as a dataframe.
@@ -165,6 +165,7 @@ def query_postgres_db(
     If you don't, you can following the instructions in the README (Start Postgres Instance) to set it up.
 
     timeout: time in seconds to wait for query to finish before timing out
+    decimal_points: number of decimal points to round floats to
     """
     engine = None
     if db_creds is None:
@@ -178,6 +179,12 @@ def query_postgres_db(
         results_df = func_timeout(
             timeout, pd.read_sql_query, args=(escaped_query, engine)
         )
+
+        # round floats to decimal_points
+        if decimal_points:
+            results_df = results_df.round(decimal_points)
+
+
         engine.dispose()  # close connection
         return results_df
     except Exception as e:
@@ -201,6 +208,7 @@ def query_postgres_temp_db(
     db_creds: dict = None,
     table_metadata_string: str = "",
     timeout: float = 10.0,
+    decimal_points: int = None,
 ) -> pd.DataFrame:
     """
     Creates a temporary db from the table metadata string, runs query on the temporary db, and returns results as a dataframe.
@@ -243,6 +251,10 @@ def query_postgres_temp_db(
             results_df = func_timeout(
                 timeout, pd.read_sql_query, args=(escaped_query, engine)
             )
+
+            # round floats to decimal_points
+            if decimal_points:
+                results_df = results_df.round(decimal_points)
             conn.close()
         engine.dispose()  # close connection
 
@@ -265,7 +277,7 @@ def query_postgres_temp_db(
 
 
 def query_snowflake_db(
-    query: str, db_name: str, db_creds: dict = None, timeout: float = 10.0
+    query: str, db_name: str, db_creds: dict = None, timeout: float = 10.0, decimal_points: int = None
 ) -> pd.DataFrame:
     """
     Runs query on snowflake db and returns results as a dataframe.
@@ -298,6 +310,11 @@ def query_snowflake_db(
         conn.close()
         # make into a dataframe
         df = pd.DataFrame(results, columns=colnames)
+
+        # round floats to decimal_points
+        if decimal_points:
+            df = df.round(decimal_points)
+
         return df
     except Exception as e:
         if cur:
@@ -409,6 +426,7 @@ def compare_query_results(
     query_category: str,
     table_metadata_string: str = "",
     timeout: float = 10.0,
+    decimal_points: int = None,
 ) -> "tuple[bool, bool]":
     """
     Compares the results of two queries and returns a tuple of booleans, where the first element is
@@ -419,9 +437,9 @@ def compare_query_results(
     queries_gold = get_all_minimal_queries(query_gold)
     if "_temp" not in db_name:
         if db_type == "postgres":
-            results_gen = query_postgres_db(query_gen, db_name, db_creds, timeout)
+            results_gen = query_postgres_db(query_gen, db_name, db_creds, timeout, decimal_points=decimal_points)
         elif db_type == "snowflake":
-            results_gen = query_snowflake_db(query_gen, db_name, db_creds, timeout)
+            results_gen = query_snowflake_db(query_gen, db_name, db_creds, timeout, decimal_points=decimal_points)
         else:
             raise ValueError(
                 f"Invalid db_type: {db_type}. Only postgres and snowflake are supported."
@@ -429,7 +447,7 @@ def compare_query_results(
     else:
         if db_type == "postgres":
             results_gen = query_postgres_temp_db(
-                query_gen, db_name, db_creds, table_metadata_string, timeout
+                query_gen, db_name, db_creds, table_metadata_string, timeout, decimal_points=decimal_points
             )
         else:
             raise ValueError(
@@ -440,9 +458,9 @@ def compare_query_results(
     for q in queries_gold:
         if "_temp" not in db_name:
             if db_type == "postgres":
-                results_gold = query_postgres_db(q, db_name, db_creds, timeout)
+                results_gold = query_postgres_db(q, db_name, db_creds, timeout, decimal_points=decimal_points)
             elif db_type == "snowflake":
-                results_gold = query_snowflake_db(q, db_name, db_creds, timeout)
+                results_gold = query_snowflake_db(q, db_name, db_creds, timeout, decimal_points=decimal_points)
             else:
                 raise ValueError(
                     f"Invalid db_type: {db_type}. Only postgres and snowflake are supported."
@@ -450,7 +468,7 @@ def compare_query_results(
         else:
             if db_type == "postgres":
                 results_gold = query_postgres_temp_db(
-                    q, db_name, db_creds, table_metadata_string, timeout
+                    q, db_name, db_creds, table_metadata_string, timeout, decimal_points=decimal_points
                 )
             else:
                 raise ValueError(

--- a/eval/eval.py
+++ b/eval/eval.py
@@ -157,7 +157,11 @@ def get_all_minimal_queries(query: str) -> "list[str]":
 
 
 def query_postgres_db(
-    query: str, db_name: str, db_creds: dict = None, timeout: float = 10.0, decimal_points: int = None
+    query: str,
+    db_name: str,
+    db_creds: dict = None,
+    timeout: float = 10.0,
+    decimal_points: int = None,
 ) -> pd.DataFrame:
     """
     Runs query on postgres db and returns results as a dataframe.
@@ -183,7 +187,6 @@ def query_postgres_db(
         # round floats to decimal_points
         if decimal_points:
             results_df = results_df.round(decimal_points)
-
 
         engine.dispose()  # close connection
         return results_df
@@ -277,7 +280,11 @@ def query_postgres_temp_db(
 
 
 def query_snowflake_db(
-    query: str, db_name: str, db_creds: dict = None, timeout: float = 10.0, decimal_points: int = None
+    query: str,
+    db_name: str,
+    db_creds: dict = None,
+    timeout: float = 10.0,
+    decimal_points: int = None,
 ) -> pd.DataFrame:
     """
     Runs query on snowflake db and returns results as a dataframe.
@@ -437,9 +444,13 @@ def compare_query_results(
     queries_gold = get_all_minimal_queries(query_gold)
     if "_temp" not in db_name:
         if db_type == "postgres":
-            results_gen = query_postgres_db(query_gen, db_name, db_creds, timeout, decimal_points=decimal_points)
+            results_gen = query_postgres_db(
+                query_gen, db_name, db_creds, timeout, decimal_points=decimal_points
+            )
         elif db_type == "snowflake":
-            results_gen = query_snowflake_db(query_gen, db_name, db_creds, timeout, decimal_points=decimal_points)
+            results_gen = query_snowflake_db(
+                query_gen, db_name, db_creds, timeout, decimal_points=decimal_points
+            )
         else:
             raise ValueError(
                 f"Invalid db_type: {db_type}. Only postgres and snowflake are supported."
@@ -447,7 +458,12 @@ def compare_query_results(
     else:
         if db_type == "postgres":
             results_gen = query_postgres_temp_db(
-                query_gen, db_name, db_creds, table_metadata_string, timeout, decimal_points=decimal_points
+                query_gen,
+                db_name,
+                db_creds,
+                table_metadata_string,
+                timeout,
+                decimal_points=decimal_points,
             )
         else:
             raise ValueError(
@@ -458,9 +474,13 @@ def compare_query_results(
     for q in queries_gold:
         if "_temp" not in db_name:
             if db_type == "postgres":
-                results_gold = query_postgres_db(q, db_name, db_creds, timeout, decimal_points=decimal_points)
+                results_gold = query_postgres_db(
+                    q, db_name, db_creds, timeout, decimal_points=decimal_points
+                )
             elif db_type == "snowflake":
-                results_gold = query_snowflake_db(q, db_name, db_creds, timeout, decimal_points=decimal_points)
+                results_gold = query_snowflake_db(
+                    q, db_name, db_creds, timeout, decimal_points=decimal_points
+                )
             else:
                 raise ValueError(
                     f"Invalid db_type: {db_type}. Only postgres and snowflake are supported."
@@ -468,7 +488,12 @@ def compare_query_results(
         else:
             if db_type == "postgres":
                 results_gold = query_postgres_temp_db(
-                    q, db_name, db_creds, table_metadata_string, timeout, decimal_points=decimal_points
+                    q,
+                    db_name,
+                    db_creds,
+                    table_metadata_string,
+                    timeout,
+                    decimal_points=decimal_points,
                 )
             else:
                 raise ValueError(

--- a/eval/gemini_runner.py
+++ b/eval/gemini_runner.py
@@ -60,7 +60,7 @@ def generate_prompt(
     return prompt
 
 
-def process_row(row, model_name):
+def process_row(row, model_name, args):
     start_time = time()
     chat = multiturn_generate_content(model_name=model_name)
     response = chat.send_message(row["prompt"])
@@ -75,7 +75,6 @@ def process_row(row, model_name):
     db_type = row["db_type"]
     question = row["question"]
     query_category = row["query_category"]
-    table_metadata_string = row["table_metadata_string"]
     exact_match = correct = 0
 
     try:
@@ -87,7 +86,7 @@ def process_row(row, model_name):
             db_creds=db_creds_all[row["db_type"]],
             question=question,
             query_category=query_category,
-            table_metadata_string=table_metadata_string,
+            decimal_points=args.decimal_points,
         )
         row["exact_match"] = int(exact_match)
         row["correct"] = int(correct)
@@ -161,7 +160,7 @@ def run_gemini_eval(args):
         with ThreadPoolExecutor(max_workers=max_workers) as executor:
             futures = []
             for row in df.to_dict("records"):
-                futures.append(executor.submit(process_row, row, model_name))
+                futures.append(executor.submit(process_row, row, model_name, args))
 
             with tqdm(as_completed(futures), total=len(futures)) as pbar:
                 for f in pbar:

--- a/eval/hf_runner.py
+++ b/eval/hf_runner.py
@@ -217,6 +217,7 @@ def run_hf_eval(args):
                         question=question,
                         query_category=query_category,
                         table_metadata_string=table_metadata_string,
+                        decimal_points=args.decimal_points,
                     )
                     row["exact_match"] = int(exact_match)
                     row["correct"] = int(correct)

--- a/eval/llama_cpp_runner.py
+++ b/eval/llama_cpp_runner.py
@@ -12,7 +12,7 @@ from utils.reporting import upload_results
 from llama_cpp import Llama
 
 
-def process_row(llm, row):
+def process_row(llm, row, args):
     start_time = time()
     prompt = row["prompt"]
     generated_query = (
@@ -50,6 +50,7 @@ def process_row(llm, row):
             question=question,
             query_category=query_category,
             table_metadata_string=table_metadata_string,
+            decimal_points=args.decimal_points,
         )
         row["exact_match"] = int(exact_match)
         row["correct"] = int(correct)
@@ -126,7 +127,7 @@ def run_llama_cpp_eval(args):
 
         with tqdm(total=len(df)) as pbar:
             for row in df.to_dict("records"):
-                row = process_row(llm, row)
+                row = process_row(llm, row, args)
                 output_rows.append(row)
                 if row["correct"]:
                     total_correct += 1

--- a/eval/mistral_runner.py
+++ b/eval/mistral_runner.py
@@ -73,7 +73,7 @@ def generate_prompt(
     return messages
 
 
-def process_row(row, model):
+def process_row(row, model, args):
     start_time = time()
     chat_response = client.chat(
         model=model,
@@ -115,6 +115,7 @@ def process_row(row, model):
             question=question,
             query_category=query_category,
             table_metadata_string=table_metadata_string,
+            decimal_points=args.decimal_points,
         )
         row["exact_match"] = int(exact_match)
         row["correct"] = int(correct)
@@ -191,7 +192,7 @@ def run_mistral_eval(args):
         with ThreadPoolExecutor(max_workers=max_workers) as executor:
             futures = []
             for row in df.to_dict("records"):
-                futures.append(executor.submit(process_row, row, model))
+                futures.append(executor.submit(process_row, row, model, args))
 
             with tqdm(as_completed(futures), total=len(futures)) as pbar:
                 for f in pbar:

--- a/eval/mlx_runner.py
+++ b/eval/mlx_runner.py
@@ -44,7 +44,7 @@ def process_row(model, tokenizer, row, args):
             question=question,
             query_category=query_category,
             table_metadata_string=table_metadata_string,
-            decimal_points=args.decimal_points
+            decimal_points=args.decimal_points,
         )
         row["exact_match"] = int(exact_match)
         row["correct"] = int(correct)

--- a/eval/mlx_runner.py
+++ b/eval/mlx_runner.py
@@ -12,7 +12,7 @@ from utils.reporting import upload_results
 from mlx_lm import load, generate
 
 
-def process_row(model, tokenizer, row):
+def process_row(model, tokenizer, row, args):
     start_time = time()
     prompt = row["prompt"]
 
@@ -44,6 +44,7 @@ def process_row(model, tokenizer, row):
             question=question,
             query_category=query_category,
             table_metadata_string=table_metadata_string,
+            decimal_points=args.decimal_points
         )
         row["exact_match"] = int(exact_match)
         row["correct"] = int(correct)
@@ -119,7 +120,7 @@ def run_mlx_eval(args):
 
         with tqdm(total=len(df)) as pbar:
             for row in df.to_dict("records"):
-                row = process_row(model, tokenizer, row)
+                row = process_row(model, tokenizer, row, args)
                 output_rows.append(row)
                 if row["correct"]:
                     total_correct += 1

--- a/eval/openai_runner.py
+++ b/eval/openai_runner.py
@@ -105,6 +105,7 @@ def run_openai_eval(args):
                             question=question,
                             query_category=query_category,
                             table_metadata_string=table_metadata_string,
+                            decimal_points=args.decimal_points,
                         )
                         row["exact_match"] = int(exact_match)
                         row["correct"] = int(correct)

--- a/eval/vllm_runner.py
+++ b/eval/vllm_runner.py
@@ -140,6 +140,7 @@ def run_vllm_eval(args):
                         question=question,
                         query_category=query_category,
                         table_metadata_string=table_metadata_string,
+                        decimal_points=args.decimal_points,
                     )
                     df.loc[i, "exact_match"] = int(exact_match)
                     df.loc[i, "correct"] = int(correct)

--- a/main.py
+++ b/main.py
@@ -8,6 +8,7 @@ if __name__ == "__main__":
     parser.add_argument("-n", "--num_questions", type=int, default=None)
     parser.add_argument("-db", "--db_type", type=str, required=True)
     parser.add_argument("-d", "--use_private_data", action="store_true")
+    parser.add_argument("-dp", "--decimal_points", type=int, default=None)
     # model-related parameters
     parser.add_argument("-g", "--model_type", type=str, required=True)
     parser.add_argument("-m", "--model", type=str)

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -428,7 +428,7 @@ def test_subset_df(test_dataframes):
 @mock.patch("eval.eval.query_postgres_db")
 def test_compare_query_results(mock_query_postgres_db):
     # Set up mock behavior
-    def mock_query_postgres_db_fn(query, db_name, db_creds, timeout) -> pd.DataFrame:
+    def mock_query_postgres_db_fn(query, db_name, db_creds, timeout, decimal_points) -> pd.DataFrame:
         if query == "SELECT id FROM users WHERE age < 18":
             return pd.DataFrame({"id": [1, 2, 3]})
         elif query == "SELECT name FROM users WHERE age < 18":

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -428,7 +428,9 @@ def test_subset_df(test_dataframes):
 @mock.patch("eval.eval.query_postgres_db")
 def test_compare_query_results(mock_query_postgres_db):
     # Set up mock behavior
-    def mock_query_postgres_db_fn(query, db_name, db_creds, timeout, decimal_points) -> pd.DataFrame:
+    def mock_query_postgres_db_fn(
+        query, db_name, db_creds, timeout, decimal_points
+    ) -> pd.DataFrame:
         if query == "SELECT id FROM users WHERE age < 18":
             return pd.DataFrame({"id": [1, 2, 3]})
         elif query == "SELECT name FROM users WHERE age < 18":


### PR DESCRIPTION
Earlier, we could get mismatches with rounded floats. For example, in the example below, the 2 frames would not be considered equal

```python
import pandas as pd
from pandas.testing import assert_frame_equal

df1 = pd.DataFrame([[1,2.123,"abc"], [2, 3.123, "xyz"]])
df2 = pd.DataFrame([[1,2.1234,"abc"], [2, 3.1234, "xyz"]])
assert_frame_equal(df1, df2) # throws an error
```

However, there are instances where we want to specify a float rounding limit beyond which both values are considered equal. In `pandas`, can do this with `df.round(n)`, where `n` refers to the number of decimal points. The function takes care of only rounding floats, and not modifying `int`, `bool`, `object` columns

```python
import pandas as pd
from pandas.testing import assert_frame_equal

df1 = pd.DataFrame([[1,2.123,"abc"], [2, 3.123, "xyz"]])
df2 = pd.DataFrame([[1,2.1234,"abc"], [2, 3.1234, "xyz"]])
assert_frame_equal(df1.round(3), df2.round(3)) # runs fine
```

This PR enabled a new, optional, `decimal_points` argument for rounding floats. This has been implemented for all runners. Here is an example specifying this for the OpenAI runner

```bash
python main.py \
  -db postgres \
  -o results/openai.csv \
  -g oa \
  -f prompts/prompt_openai.md \
  -m gpt-3.5-turbo-0613 \
  -n 10 \
  -p 5 \
  -dp 3
```