### PR TITLE
Update model runners

### DIFF
--- a/eval/hf_runner.py
+++ b/eval/hf_runner.py
@@ -86,7 +86,7 @@ def run_hf_eval(args):
     # initialize tokenizer and model
     tokenizer, model = get_tokenizer_model(model_name, adapter_path)
 
-    if "llama-3" in model_name.lower():
+    if "8b" in model_name.lower():
         # do this since it doesn't seem to have been done by default
         tokenizer.padding_side = "left"
 
@@ -156,7 +156,7 @@ def run_hf_eval(args):
         def chunk_dataframe(df, chunk_size):
             """Yield successive chunk_size chunks from df."""
             for i in range(0, len(df), chunk_size):
-                yield df[i : i + chunk_size]
+                yield df[i : min(i + chunk_size, len(df))]
 
         df_chunks = list(chunk_dataframe(df, args.batch_size))
 
@@ -165,7 +165,7 @@ def run_hf_eval(args):
                 prompts = batch["prompt"].tolist()
                 generated_queries = pipe(
                     prompts,
-                    max_new_tokens=300,
+                    max_new_tokens=600,
                     do_sample=False,
                     num_beams=num_beams,
                     num_return_sequences=1,

--- a/gcs_eval.py
+++ b/gcs_eval.py
@@ -30,7 +30,11 @@ def download_evaluate():
             .split("\n")
         )
         for gcs_model_path in existing_models:
-            model_name = gcs_model_path.replace(GCS_MODEL_DIR, "").replace("/", "")
+            model_name = (
+                gcs_model_path.replace(GCS_MODEL_DIR, "").replace("/", "").strip()
+            )
+            if not model_name:
+                continue
             local_model_path = os.path.join(LOCAL_MODEL_DIR, model_name)
             if not os.path.exists(local_model_path):
                 print(f"Downloading model: {model_name}")


### PR DESCRIPTION
Updates to runners:
API
* Made it take in an additional `-m` parameter that will help us tell the script which model's tokenizer to load
VLLM
* Enable batching. When set to `-bs 200` it reverts to original vllm generation behaviour/scores (see `[scores](https://docs.google.com/spreadsheets/d/1rkrhQmrpTWMNorrVQxM_KnHslKQiJDSs_kzxt6fmKbI/edit#gid=736994119)`).
HF
* Token(izer) updates

Also fixed a small edge case for the `gcs_eval.py` script where it was reading/processing empty lines