### PR TITLE
Added a bedrock runner to make it easier to run models straight from bedrock

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,17 @@ python -W ignore main.py \
 ```
 While you can do the same for the other runners, the time savings are most significant when loading a large model locally, vs calling an always-on API.
 
+### Bedrock
+```bash
+python -W ignore main.py \
+  -db postgres \
+  -q "data/questions_gen_postgres.csv" \
+  -o results/llama3_70b.csv \
+  -g bedrock \
+  -f prompts/prompt.md \
+  -m meta.llama3-70b-instruct-v1:0
+```
+
 
 ### Llama CPP
 To run the eval using Llama CPP, you can use the following code. Before running this, you must install `llama-cpp-python` with the following (on Apple Silicon)

--- a/eval/bedrock_runner.py
+++ b/eval/bedrock_runner.py
@@ -1,0 +1,187 @@
+import boto3
+import json
+import os
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import Optional
+
+from eval.eval import compare_query_results
+import pandas as pd
+from utils.gen_prompt import generate_prompt
+from utils.questions import prepare_questions_df
+from utils.creds import db_creds_all
+from tqdm import tqdm
+from time import time
+from utils.reporting import upload_results
+
+bedrock = boto3.client(service_name='bedrock-runtime')
+
+def process_row(row, modelId, decimal_points):
+    start_time = time()
+    
+    body = json.dumps({
+        "prompt": row["prompt"],
+        "max_gen_len": 600,
+        "temperature": 0,
+        "top_p": 1,
+    })
+
+    modelId = modelId
+    accept = 'application/json'
+    contentType = 'application/json'
+    response = bedrock.invoke_model(body=body, modelId=modelId, accept=accept, contentType=contentType)
+    model_response = json.loads(response['body'].read())
+
+    generated_query = model_response['generation']
+    end_time = time()
+
+    print(generated_query)
+
+    generated_query = (
+        generated_query.split("[/SQL]")[0].split("```")[-1].split("```")[0].split(";")[0].strip()
+        + ";"
+    )
+
+    row["generated_query"] = generated_query
+    row["latency_seconds"] = end_time - start_time
+    row["tokens_used"] = None
+    golden_query = row["query"]
+    db_name = row["db_name"]
+    db_type = row["db_type"]
+    question = row["question"]
+    query_category = row["query_category"]
+    table_metadata_string = row["table_metadata_string"]
+    exact_match = correct = 0
+
+    try:
+        exact_match, correct = compare_query_results(
+            query_gold=golden_query,
+            query_gen=generated_query,
+            db_name=db_name,
+            db_type=db_type,
+            db_creds=db_creds_all[row["db_type"]],
+            question=question,
+            query_category=query_category,
+            table_metadata_string=table_metadata_string,
+            decimal_points=decimal_points,
+        )
+        row["exact_match"] = int(exact_match)
+        row["correct"] = int(correct)
+        row["error_msg"] = ""
+    except Exception as e:
+        row["error_db_exec"] = 1
+        row["error_msg"] = f"QUERY EXECUTION ERROR: {e}"
+
+    return row
+
+
+def run_bedrock_eval(args):
+    # get params from args
+    questions_file_list = args.questions_file
+    prompt_file_list = args.prompt_file
+    num_questions = args.num_questions
+    public_data = not args.use_private_data
+    output_file_list = args.output_file
+    k_shot = args.k_shot
+    max_workers = args.parallel_threads
+    db_type = args.db_type
+    decimal_points = args.decimal_points
+    modelId = args.model
+
+    for questions_file, prompt_file, output_file in zip(
+        questions_file_list, prompt_file_list, output_file_list
+    ):
+        print(f"Using prompt file {prompt_file}")
+        # get questions
+        print("Preparing questions...")
+        print(
+            f"Using {'all' if num_questions is None else num_questions} question(s) from {questions_file}"
+        )
+        df = prepare_questions_df(questions_file, db_type, num_questions, k_shot)
+        # create a prompt for each question
+        df["prompt"] = df[
+            [
+                "question",
+                "db_name",
+                "instructions",
+                "k_shot_prompt",
+                "glossary",
+                "table_metadata_string",
+                "prev_invalid_sql",
+                "prev_error_msg",
+                "question_0",
+                "query_0",
+                "question_1",
+                "query_1",
+            ]
+        ].apply(
+            lambda row: generate_prompt(
+                prompt_file,
+                row["question"],
+                row["db_name"],
+                row["instructions"],
+                row["k_shot_prompt"],
+                row["glossary"],
+                row["table_metadata_string"],
+                row["prev_invalid_sql"],
+                row["prev_error_msg"],
+                row["question_0"],
+                row["query_0"],
+                row["question_1"],
+                row["query_1"],
+                public_data,
+                args.num_columns,
+                args.shuffle_metadata,
+            ),
+            axis=1,
+        )
+
+        total_tried = 0
+        total_correct = 0
+        output_rows = []
+
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            futures = []
+            for row in df.to_dict("records"):
+                futures.append(
+                    executor.submit(
+                        process_row, row, decimal_points
+                    )
+                )
+
+            with tqdm(as_completed(futures), total=len(futures)) as pbar:
+                for f in pbar:
+                    row = f.result()
+                    output_rows.append(row)
+                    if row["correct"]:
+                        total_correct += 1
+                    total_tried += 1
+                    pbar.update(1)
+                    pbar.set_description(
+                        f"Correct so far: {total_correct}/{total_tried} ({100*total_correct/total_tried:.2f}%)"
+                    )
+
+        output_df = pd.DataFrame(output_rows)
+        del output_df["prompt"]
+        print(output_df.groupby("query_category")[["correct", "error_db_exec"]].mean())
+        output_df = output_df.sort_values(by=["db_name", "query_category", "question"])
+        # get directory of output_file and create if not exist
+        output_dir = os.path.dirname(output_file)
+        if not os.path.exists(output_dir):
+            os.makedirs(output_dir)
+        try:
+            output_df.to_csv(output_file, index=False, float_format="%.2f")
+        except:
+            output_df.to_pickle(output_file)
+
+        results = output_df.to_dict("records")
+        # upload results
+        with open(prompt_file, "r") as f:
+            prompt = f.read()
+        if args.upload_url is not None:
+            upload_results(
+                results=results,
+                url=args.upload_url,
+                runner_type="api_runner",
+                prompt=prompt,
+                args=args,
+            )

--- a/eval/bedrock_runner.py
+++ b/eval/bedrock_runner.py
@@ -47,8 +47,6 @@ def process_row(row, model_id, decimal_points):
         + ";"
     )
 
-    print(generated_query)
-
     row["generated_query"] = generated_query
     row["latency_seconds"] = end_time - start_time
     row["tokens_used"] = None

--- a/eval/bedrock_runner.py
+++ b/eval/bedrock_runner.py
@@ -49,14 +49,9 @@ def process_row(row, model_id, decimal_points):
         )
     else:
         generated_query = (
-            generated_query.split("[/SQL]")[0]
-            .split("```")[1]
-            .split(";")[0]
-            .strip()
+            generated_query.split("[/SQL]")[0].split("```")[1].split(";")[0].strip()
             + ";"
         )
-    
-    print(generated_query)
 
     row["generated_query"] = generated_query
     row["latency_seconds"] = end_time - start_time

--- a/eval/bedrock_runner.py
+++ b/eval/bedrock_runner.py
@@ -38,14 +38,25 @@ def process_row(row, model_id, decimal_points):
     generated_query = model_response["generation"]
     end_time = time()
 
-    generated_query = (
-        generated_query.split("[/SQL]")[0]
-        .split("```sql")[-1]
-        .split("```")[0]
-        .split(";")[0]
-        .strip()
-        + ";"
-    )
+    print(generated_query)
+
+    if "```sql" in generated_query:
+        generated_query = (
+            generated_query.split("[/SQL]")[0]
+            .split("```sql")[-1]
+            .split("```")[0]
+            .split(";")[0]
+            .strip()
+            + ";"
+        )
+    else:
+        generated_query = (
+            generated_query.split("[/SQL]")[0]
+            .split("```")[-1]
+            .split(";")[0]
+            .strip()
+            + ";"
+        )
 
     row["generated_query"] = generated_query
     row["latency_seconds"] = end_time - start_time

--- a/eval/bedrock_runner.py
+++ b/eval/bedrock_runner.py
@@ -38,8 +38,6 @@ def process_row(row, model_id, decimal_points):
     generated_query = model_response["generation"]
     end_time = time()
 
-    print(generated_query)
-
     if "```sql" in generated_query:
         generated_query = (
             generated_query.split("[/SQL]")[0]
@@ -52,11 +50,13 @@ def process_row(row, model_id, decimal_points):
     else:
         generated_query = (
             generated_query.split("[/SQL]")[0]
-            .split("```")[-1]
+            .split("```")[1]
             .split(";")[0]
             .strip()
             + ";"
         )
+    
+    print(generated_query)
 
     row["generated_query"] = generated_query
     row["latency_seconds"] = end_time - start_time

--- a/main.py
+++ b/main.py
@@ -116,6 +116,10 @@ if __name__ == "__main__":
         from eval.mistral_runner import run_mistral_eval
 
         run_mistral_eval(args)
+    elif args.model_type == "bedrock":
+        from eval.bedrock_runner import run_bedrock_eval
+
+        run_bedrock_eval(args)
     else:
         raise ValueError(
             f"Invalid model type: {args.model_type}. Model type must be one of: 'oa', 'hf', 'anthropic', 'vllm', 'api', 'llama_cpp', 'mlx', 'gemini', 'mistral'"


### PR DESCRIPTION
To run this, we can go 

```bash
python -W ignore main.py \
  -db postgres \
  -q "data/questions_gen_postgres.csv" \
  -o results/llama3_70b.csv \
  -g bedrock \
  -f prompts/prompt.md \
  -m meta.llama3-70b-instruct-v1:0 \
  -p 5

Correct so far: 147/200 (73.50%): 100%|███████████████████████████████████████████████████| 200/200 [02:42<00:00,  1.23it/s]
                 correct  error_db_exec
query_category                         
date_functions  0.680000       0.200000
group_by        0.828571       0.000000
instruct        0.771429       0.114286
order_by        0.885714       0.000000
ratio           0.342857       0.114286
table_join      0.885714       0.000000
```