### PR TITLE
fix temperature/top_p warning

### DIFF
--- a/eval/hf_runner.py
+++ b/eval/hf_runner.py
@@ -172,8 +172,8 @@ def run_hf_eval(args):
                     return_full_text=False,
                     eos_token_id=tokenizer.eos_token_id,
                     pad_token_id=tokenizer.eos_token_id,
-                    temperature=1.0,
-                    top_p=1.0,
+                    temperature=None,
+                    top_p=None,
                 )
                 gc.collect()
                 torch.cuda.empty_cache()

--- a/eval/hf_runner.py
+++ b/eval/hf_runner.py
@@ -172,6 +172,8 @@ def run_hf_eval(args):
                     return_full_text=False,
                     eos_token_id=tokenizer.eos_token_id,
                     pad_token_id=tokenizer.eos_token_id,
+                    temperature=1.0,
+                    top_p=1.0,
                 )
                 gc.collect()
                 torch.cuda.empty_cache()

--- a/gcs_eval.py
+++ b/gcs_eval.py
@@ -11,7 +11,7 @@ from eval.vllm_runner import run_vllm_eval
 # GCS_MODEL_EVAL_DIR: gcs path where the evaluated models will be shifted to
 # LOCAL_MODEL_DIR: local path where the models will be downloaded
 # SQL_EVAL_DIR: local path where the sql-eval repo is cloned
-GCS_MODEL_DIR = "gs://defog-finetuning/fsdp_models"
+GCS_MODEL_DIR = "gs://defog-finetuning/fsdp_hpp2"
 GCS_MODEL_EVAL_DIR = "gs://defog-finetuning/fsdp_evaluated"
 LOCAL_MODEL_DIR = os.path.expanduser("/models/fsdp")
 SQL_EVAL_DIR = os.path.expanduser("~/sql-eval")
@@ -86,6 +86,8 @@ def download_evaluate():
                         prompt_file,
                         "-m",
                         local_model_path,
+                        "-bs",
+                        "16",
                     ],
                     check=True,
                 )


### PR DESCRIPTION
Fix temperature/top_p warnings by setting it explicitly when generating
Add batch_size param to gcs_eval.py

Tested with the following and the warnings don't show up anymore:
```
python3 main.py \
  -db postgres \
  -q data/instruct_basic_postgres.csv data/instruct_advanced_postgres.csv data/questions_gen_postgres.csv \
  -o "results/${model_name}_beam1_basic_hf.csv" "results/${model_name}_beam1_advanced_hf.csv" "results/${model_name}_beam1_v1_hf.csv" \
  -g hf \
  -b 1 \
  -c 0 \
  -f "prompts/prompt.md" \
  -m "${model_name}"
```