### PR TITLE
Enable tgi via api type

### DIFF
--- a/eval/api_runner.py
+++ b/eval/api_runner.py
@@ -14,19 +14,43 @@ import requests
 from utils.reporting import upload_results
 
 
-def process_row(row, api_url, num_beams, decimal_points):
+def mk_vllm_json(prompt, num_beams):
+    return {
+        "prompt": prompt,
+        "n": 1,
+        "use_beam_search": num_beams > 1,
+        "best_of": num_beams,
+        "temperature": 0,
+        "stop": [";", "```"],
+        "max_tokens": 1024,
+    }
+
+
+def mk_tgi_json(prompt, num_beams):
+    # see swagger docs for /generate for the full list of parameters:
+    # https://huggingface.github.io/text-generation-inference/#/Text%20Generation%20Inference/generate
+    return {
+        "inputs": prompt,
+        "parameters": {
+            "best_of": num_beams,
+            "do_sample": num_beams > 1,
+            "return_full_text": False,
+            "max_new_tokens": 1024,
+        },
+    }
+
+
+def process_row(row, api_url: str, api_type: str, num_beams: int, decimal_points: int):
     start_time = time()
+    if api_type == "tgi":
+        json_data = mk_tgi_json(row["prompt"], num_beams)
+    elif api_type == "vllm":
+        json_data = mk_vllm_json(row["prompt"], num_beams)
+    else:
+        raise ValueError(f"Invalid api_type: {api_type}")
     r = requests.post(
         api_url,
-        json={
-            "prompt": row["prompt"],
-            "n": 1,
-            "use_beam_search": num_beams > 1,
-            "best_of": num_beams,
-            "temperature": 0,
-            "stop": [";", "```"],
-            "max_tokens": 4000,
-        },
+        json=json_data,
     )
     end_time = time()
     if "[SQL]" not in row["prompt"]:
@@ -34,10 +58,17 @@ def process_row(row, api_url, num_beams, decimal_points):
             r.json()["text"][0].split("```")[-1].split("```")[0].split(";")[0].strip()
             + ";"
         )
+    elif api_type == "tgi":
+        # we do not return the original prompt in tgi
+        try:
+            generated_query = r.json()["generated_text"]
+        except KeyError:
+            print(r.json())
+            generated_query = ""
     else:
         generated_query = r.json()["text"][0]
         if "[SQL]" in generated_query:
-            generated_query = generated_query.split("[SQL]")[1].strip()
+            generated_query = generated_query.split("[SQL]", 1)[1].strip()
         else:
             generated_query = generated_query.strip()
 
@@ -81,6 +112,7 @@ def run_api_eval(args):
     num_questions = args.num_questions
     public_data = not args.use_private_data
     api_url = args.api_url
+    api_type = args.api_type
     output_file_list = args.output_file
     k_shot = args.k_shot
     num_beams = args.num_beams
@@ -145,7 +177,7 @@ def run_api_eval(args):
             for row in df.to_dict("records"):
                 futures.append(
                     executor.submit(
-                        process_row, row, api_url, num_beams, decimal_points
+                        process_row, row, api_url, api_type, num_beams, decimal_points
                     )
                 )
 

--- a/eval/api_runner.py
+++ b/eval/api_runner.py
@@ -20,8 +20,8 @@ def mk_vllm_json(prompt, num_beams):
         "n": 1,
         "use_beam_search": num_beams > 1,
         "best_of": num_beams,
-        "temperature": 0,
-        "stop": [";", "```"],
+        # "temperature": 0,
+        # "stop": [";", "```"],
         "max_tokens": 1024,
     }
 
@@ -53,18 +53,18 @@ def process_row(row, api_url: str, api_type: str, num_beams: int, decimal_points
         json=json_data,
     )
     end_time = time()
-    if "[SQL]" not in row["prompt"]:
-        generated_query = (
-            r.json()["text"][0].split("```")[-1].split("```")[0].split(";")[0].strip()
-            + ";"
-        )
-    elif api_type == "tgi":
+    if api_type == "tgi":
         # we do not return the original prompt in tgi
         try:
             generated_query = r.json()["generated_text"]
         except KeyError:
             print(r.json())
             generated_query = ""
+    elif "[SQL]" not in row["prompt"]:
+        generated_query = (
+            r.json()["text"][0].split("```")[-1].split("```")[0].split(";")[0].strip()
+            + ";"
+        )
     else:
         generated_query = r.json()["text"][0]
         if "[SQL]" in generated_query:

--- a/main.py
+++ b/main.py
@@ -14,6 +14,7 @@ if __name__ == "__main__":
     parser.add_argument("-m", "--model", type=str)
     parser.add_argument("-a", "--adapter", type=str)
     parser.add_argument("--api_url", type=str)
+    parser.add_argument("--api_type", type=str)
     # inference-technique-related parameters
     parser.add_argument("-f", "--prompt_file", nargs="+", type=str, required=True)
     parser.add_argument("-b", "--num_beams", type=int, default=1)
@@ -97,6 +98,10 @@ if __name__ == "__main__":
 
         run_hf_eval(args)
     elif args.model_type == "api":
+        assert args.api_url is not None, "api_url must be provided for api model"
+        assert args.api_type is not None, "api_type must be provided for api model"
+        assert args.api_type in ["vllm", "tgi"], "api_type must be one of 'vllm', 'tgi'"
+
         from eval.api_runner import run_api_eval
 
         run_api_eval(args)


### PR DESCRIPTION
Enable testing of inference using TGI via the api runner.
We only need to change the way the request parameters are formatted, and facilitate this simple switching via the new flag `--api_type`
Updated README to show how to use it.