### PR TITLE
Added install step to CONTRIBUTING.md; refactoring install step in README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,9 +3,21 @@
 Thank you for your interest in contributing to our project! We value your contributions and want to ensure a smooth and collaborative experience for everyone. Please take a moment to review the following guidelines.
 
 ## Table of Contents
+- [Installation](#installation)
 - [Linting](#linting)
 - [Testing](#testing)
 - [Submitting Changes](#submitting-changes)
+
+## Installation
+
+Firstly, clone the repository where we store our database data and schema. Install all Python libraries listed in the `requirements.txt` file. Download the spacy model used in the NER heuristic for our [metadata-pruning method](https://github.com/defog-ai/sql-eval/blob/main/utils/pruning.py). Finally, install the library:
+```bash
+git clone https://github.com/defog-ai/defog-data.git
+cd defog-data
+pip install -r requirements.txt
+python -m spacy download en_core_web_sm
+pip install -e .
+```
 
 ## Linting
 

--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@ This is a comprehensive set of instructions that assumes basic familiarity with 
 
 ### Install Dependencies
 
-Firstly, install all Python libraries listed in the `requirements.txt` file. You would also need to download the spacy model used in the NER heuristic for our [metadata-pruning method](https://github.com/defog-ai/sql-eval/blob/main/utils/pruning.py). Also, you would need to clone the repository where we store our database data and schema, and install the library.
+Firstly, clone the repository where we store our database data and schema. Install all Python libraries listed in the `requirements.txt` file. You would also need to download the spacy model used in the NER heuristic for our [metadata-pruning method](https://github.com/defog-ai/sql-eval/blob/main/utils/pruning.py). Finally, install the library.
 ```bash
-pip install -r requirements.txt
-python -m spacy download en_core_web_sm
 git clone https://github.com/defog-ai/defog-data.git
 cd defog-data
+pip install -r requirements.txt
+python -m spacy download en_core_web_sm
 pip install -e .
 ```
 


### PR DESCRIPTION
I noticed that there was a mistake in the install step. In order to install deps, you would need to first clone the repository, as you otherwise would not have access to the `requirements.txt` file.

I therefore restructuring the installation instructions to follow a more natural flow and updated the corresponding text.

I am also used to the same installation steps being part of the `CONTRIBUTING.md` markdown, which I believe is quite standard. When making my initial PR, I failed to see that I needed to download the `NER heuristic`, which caused tests to fail. This could have been resolved by having these steps in the contrib markdown directly, as this is what I followed when making the PR.