### PR TITLE
gcs eval for checkpoint weights

### DIFF
--- a/gcs_eval_checkpoints.py
+++ b/gcs_eval_checkpoints.py
@@ -34,22 +34,20 @@ def download_evaluate():
         existing_checkpoints = []
         for existing_model_folder in existing_models:
             results = (
-                (
-                    subprocess.run(
-                        ["gsutil", "ls", existing_model_folder], capture_output=True
-                    )
-                    .stdout.decode("utf-8")
-                    .split("\n")
+                subprocess.run(
+                    ["gsutil", "ls", existing_model_folder], capture_output=True
                 )
+                .stdout.decode("utf-8")
+                .split("\n")
             )
             for path in results:
                 if path.startswith(GCS_MODEL_DIR) and "checkpoint" in path:
                     existing_checkpoints.append(path)
         print(existing_checkpoints)
         for gcs_model_checkpoint_path in existing_checkpoints:
-            run_name_checkpoint = (
-                gcs_model_checkpoint_path.replace(GCS_MODEL_DIR, "").strip(" /")
-            )
+            run_name_checkpoint = gcs_model_checkpoint_path.replace(
+                GCS_MODEL_DIR, ""
+            ).strip(" /")
             if not run_name_checkpoint:
                 print("No model found, skipping.")
                 continue
@@ -60,9 +58,18 @@ def download_evaluate():
                 local_run_name_folder = os.path.join(LOCAL_MODEL_DIR, run_name)
                 os.makedirs(local_run_name_folder, exist_ok=True)
                 # download from gcs's checkpoint folder into a run name folder
-                print(f"Downloading from {gcs_model_checkpoint_path} to {local_run_name_folder}")
+                print(
+                    f"Downloading from {gcs_model_checkpoint_path} to {local_run_name_folder}"
+                )
                 subprocess.run(
-                    ["gsutil", "-m", "cp", "-r", gcs_model_checkpoint_path, local_run_name_folder]
+                    [
+                        "gsutil",
+                        "-m",
+                        "cp",
+                        "-r",
+                        gcs_model_checkpoint_path,
+                        local_run_name_folder,
+                    ]
                 )
             else:
                 print(f"Model folder exists: {run_name_checkpoint}")
@@ -116,7 +123,13 @@ def download_evaluate():
                 )
                 # move the model to the evaluated directory once evaluated successfully
                 subprocess.run(
-                    ["gsutil", "-m", "mv", gcs_model_checkpoint_path, GCS_MODEL_EVAL_DIR],
+                    [
+                        "gsutil",
+                        "-m",
+                        "mv",
+                        gcs_model_checkpoint_path,
+                        GCS_MODEL_EVAL_DIR,
+                    ],
                     check=True,
                 )
                 subprocess.run(["rm", "-rf", local_model_path], check=True)

--- a/gcs_eval_checkpoints.py
+++ b/gcs_eval_checkpoints.py
@@ -2,13 +2,16 @@ import os
 import subprocess
 import time
 
+# Alternate version of gcs_eval if you're working with nested checkpoint folders
+# with model weights instead of model weight folders directly
+
 # edit these 4 paths as per your setup
 # GCS_MODEL_DIR: gcs path where the models are stored.
 # this should be the same as GCS_MODEL_DIR in model_uploader.py
 # GCS_MODEL_EVAL_DIR: gcs path where the evaluated models will be shifted to
 # LOCAL_MODEL_DIR: local path where the models will be downloaded
 # SQL_EVAL_DIR: local path where the sql-eval repo is cloned
-GCS_MODEL_DIR = "gs://defog-finetuning/fsdp_wrong_sql_eval"
+GCS_MODEL_DIR = "gs://defog-finetuning/fsdp_hpp"
 GCS_MODEL_EVAL_DIR = "gs://defog-finetuning/fsdp_evaluated"
 LOCAL_MODEL_DIR = os.path.expanduser("/models/fsdp")
 SQL_EVAL_DIR = os.path.expanduser("~/sql-eval")
@@ -28,32 +31,52 @@ def download_evaluate():
             .stdout.decode("utf-8")
             .split("\n")
         )
-        for gcs_model_path in existing_models:
-            model_name = (
-                gcs_model_path.replace(GCS_MODEL_DIR, "").replace("/", "").strip()
+        existing_checkpoints = []
+        for existing_model_folder in existing_models:
+            results = (
+                (
+                    subprocess.run(
+                        ["gsutil", "ls", existing_model_folder], capture_output=True
+                    )
+                    .stdout.decode("utf-8")
+                    .split("\n")
+                )
             )
-            if not model_name:
+            for path in results:
+                if path.startswith(GCS_MODEL_DIR) and "checkpoint" in path:
+                    existing_checkpoints.append(path)
+        print(existing_checkpoints)
+        for gcs_model_checkpoint_path in existing_checkpoints:
+            run_name_checkpoint = (
+                gcs_model_checkpoint_path.replace(GCS_MODEL_DIR, "").strip(" /")
+            )
+            if not run_name_checkpoint:
+                print("No model found, skipping.")
                 continue
-            local_model_path = os.path.join(LOCAL_MODEL_DIR, model_name)
+            local_model_path = os.path.join(LOCAL_MODEL_DIR, run_name_checkpoint)
+            run_name = run_name_checkpoint.split("/checkpoint-", 1)[0]
+            print(f"Model name: {run_name_checkpoint}")
             if not os.path.exists(local_model_path):
-                print(f"Downloading model: {model_name}")
-                # download from gcs
+                local_run_name_folder = os.path.join(LOCAL_MODEL_DIR, run_name)
+                os.makedirs(local_run_name_folder, exist_ok=True)
+                # download from gcs's checkpoint folder into a run name folder
+                print(f"Downloading from {gcs_model_checkpoint_path} to {local_run_name_folder}")
                 subprocess.run(
-                    ["gsutil", "-m", "cp", "-r", gcs_model_path, LOCAL_MODEL_DIR]
+                    ["gsutil", "-m", "cp", "-r", gcs_model_checkpoint_path, local_run_name_folder]
                 )
             else:
-                print(f"Model folder exists: {model_name}")
+                print(f"Model folder exists: {run_name_checkpoint}")
             try:
                 # run evaluation
                 # python3 main.py \
                 #   -db postgres \
                 #   -q data/instruct_basic_postgres.csv data/instruct_advanced_postgres.csv data/questions_gen_postgres.csv \
-                #   -o "results/${model_name}_beam4_basic.csv" "results/${model_name}_beam4_advanced.csv" "results/${model_name}_beam4_v1.csv" \
+                #   -o "results/${run_name_checkpoint}_beam4_basic.csv" "results/${run_name_checkpoint}_beam4_advanced.csv" "results/${run_name_checkpoint}_beam4_v1.csv" \
                 #   -g vllm \
                 #   -b 4 \
                 #   -c 0 \
                 #   -f "prompts/prompt.md" \
-                #   -m "/models/fsdp/${model_name}"
+                #   -m "/models/fsdp/${run_name_checkpoint}"
                 question_files = [
                     "data/instruct_basic_postgres.csv",
                     "data/instruct_advanced_postgres.csv",
@@ -61,10 +84,11 @@ def download_evaluate():
                 ]
                 prompt_file = "prompts/prompt.md"
                 output_files = [
-                    f"results/{model_name}_beam{NUM_BEAMS}_basic.csv",
-                    f"results/{model_name}_beam{NUM_BEAMS}_advanced.csv",
-                    f"results/{model_name}_beam{NUM_BEAMS}_v1.csv",
+                    f"results/{run_name_checkpoint}_beam{NUM_BEAMS}_basic.csv",
+                    f"results/{run_name_checkpoint}_beam{NUM_BEAMS}_advanced.csv",
+                    f"results/{run_name_checkpoint}_beam{NUM_BEAMS}_v1.csv",
                 ]
+                os.makedirs(os.path.join("results", run_name), exist_ok=True)
                 subprocess.run(
                     [
                         "python3",
@@ -86,13 +110,13 @@ def download_evaluate():
                         "-m",
                         local_model_path,
                         "-bs",
-                        "16",
+                        "200",
                     ],
                     check=True,
                 )
                 # move the model to the evaluated directory once evaluated successfully
                 subprocess.run(
-                    ["gsutil", "-m", "mv", gcs_model_path, GCS_MODEL_EVAL_DIR],
+                    ["gsutil", "-m", "mv", gcs_model_checkpoint_path, GCS_MODEL_EVAL_DIR],
                     check=True,
                 )
                 subprocess.run(["rm", "-rf", local_model_path], check=True)


### PR DESCRIPTION
Added a script like `gcs_eval.py` but for working with nested folders of weights, for example:
```
models/
├── model1/
│   ├── checkpoint-500/ # contains the safetensors
│   └── checkpoint-1000/
└── model2/
    ├── checkpoint-500/
    └── checkpoint-1000/
```
We keep the original `gcs_eval.py` around for users who want to work with non-nested folders of weights, for example:
```
models/
├── model1/ # contains the safetensors
└── model2/
```
For context, you can run this script `python3 gcs_eval.py` and it will continuously pull models from gcs, eval it (outputting the results/csv locally), and then shift the evaluated model into a different directory on gcs.