### PR TITLE
Update requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This is a comprehensive set of instructions that assumes basic familiarity with 
 
 ### Install Dependencies
 
-Firstly, clone the repository where we store our database data and schema. Install all Python libraries listed in the `requirements.txt` file. You would also need to download the spacy model used in the NER heuristic for our [metadata-pruning method](https://github.com/defog-ai/sql-eval/blob/main/utils/pruning.py). Finally, install the library.
+Firstly, clone the repository where we store our database data and schema. Install all Python libraries listed in the `requirements.txt` file. You would also need to download the spacy model if you're using the NER heuristic for our [metadata-pruning method](https://github.com/defog-ai/sql-eval/blob/main/utils/pruning.py) (set by c=0, more below). Finally, install the library.
 ```bash
 git clone https://github.com/defog-ai/defog-data.git
 cd defog-data

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,5 @@
-accelerate
 anthropic
 argparse
-git+https://github.com/defog-ai/defog-data.git
 func_timeout
 mistralai
 openai>=1.1.0


### PR DESCRIPTION
Remove unused `accelerate` package requirement for sql-eval.
We also don't need `defog-data` as we're getting the users to install it in the `README.md`