### PR TITLE
Api server updates

### DIFF
--- a/utils/api_server.py
+++ b/utils/api_server.py
@@ -51,9 +51,7 @@ async def generate(request: Request) -> Response:
     sampling_params = SamplingParams(**request_dict)
     request_id = random_uuid()
     tokenizer = await engine.get_tokenizer()
-    prompt_token_ids = tokenizer.encode(
-                text=prompt,
-                add_special_tokens=False)
+    prompt_token_ids = tokenizer.encode(text=prompt, add_special_tokens=False)
     print(f"prompt_token_ids: {prompt_token_ids}")
     if prompt_token_ids[0] != tokenizer.bos_token_id:
         prompt_token_ids = [tokenizer.bos_token_id] + prompt_token_ids
@@ -62,7 +60,7 @@ async def generate(request: Request) -> Response:
         prompt=None,
         sampling_params=sampling_params,
         request_id=request_id,
-        prompt_token_ids=prompt_token_ids
+        prompt_token_ids=prompt_token_ids,
     )
 
     # Streaming case


### PR DESCRIPTION
Problem: we were implicitly adding another bos token inside the vllm engine (in addition to the one in the prompt). This caused double bos tokens for our prompts during evaluation and a slight degradation.

Solution: Modify our api_server.py to ensure that we don't create double bos tokens by not adding special tokens (bos/eos) during the token encoding and only add the bos if it's missing after. We preferred modifying it in the api_server.py to avoid having to specify the tokenizer for api server runs and customizing the prompt based on the model/tokenizer revision.

Alternative considered: Modify api runner to pass in the prompt_token_ids directly. However, this would not have broader compatibility with the open ai server formats, or with the vanilla api server from vllm, since those only expect a prompt of type string and not token ids.