### PR TITLE
small changes to vllm runner

### DIFF
--- a/eval/vllm_runner.py
+++ b/eval/vllm_runner.py
@@ -32,11 +32,11 @@ def run_vllm_eval(args):
     tokenizer = AutoTokenizer.from_pretrained(model_name)
     tokenizer.pad_token_id = tokenizer.eos_token_id
     if not args.quantized:
-        llm = LLM(model=model_name, tensor_parallel_size=torch.cuda.device_count())
+        llm = LLM(model=model_name, tensor_parallel_size=1)
     else:
         llm = LLM(
             model=model_name,
-            tensor_parallel_size=torch.cuda.device_count(),
+            tensor_parallel_size=1,
             quantization="AWQ",
         )
 
@@ -136,7 +136,9 @@ def run_vllm_eval(args):
             start_time = time.time()
             # outputs = llm.generate(prompts, sampling_params) # if you prefer to use prompts instead of token_ids
             outputs = llm.generate(
-                sampling_params=sampling_params, prompt_token_ids=prompt_tokens
+                sampling_params=sampling_params,
+                prompt_token_ids=prompt_tokens,
+                use_tqdm=False,
             )
             print(
                 f"Generated {len(outputs)} completions in {time.time() - start_time:.2f} seconds"

--- a/run_checkpoints.sh
+++ b/run_checkpoints.sh
@@ -1,0 +1,32 @@
+#!/bin/zsh
+
+model_names=("sqlcoder_8b_fullft_ds_009_llama3_mgn1_b1_0900_b2_0990")
+
+# Loop over model names
+for model_name in "${model_names[@]}"; do
+  # list the folder names in /models/combined/${model_name}
+  model_dir="/workspace/finetuning/models/${model_name}"
+  echo "Model directory: ${model_dir}"
+  checkpoints=($(ls $model_dir))
+  echo "Checkpoints: ${checkpoints}"
+  # Loop over checkpoints
+  for checkpoint in "${checkpoints[@]}"; do
+    # skip if does not start with "checkpoint-"
+    if [[ ! $checkpoint == checkpoint-* ]]; then
+      continue
+    fi
+    model_path="${model_dir}/${checkpoint}"
+    checkpoint_num=$(echo $checkpoint | cut -d'-' -f2)
+    echo "Running model ${model_name} checkpoint ${checkpoint_num}"
+    python -W ignore main.py \
+      -db postgres \
+      -q data/instruct_basic_postgres.csv data/instruct_advanced_postgres.csv data/questions_gen_postgres.csv \
+      -o "results/${model_name}/c${checkpoint_num}_basic_api_a100.csv" "results/${model_name}/c${checkpoint_num}_advanced_api_a100.csv" "results/${model_name}/c${checkpoint_num}_v1_api_a100.csv" \
+      -g vllm \
+      -m "$model_path" \
+      -c 0 \
+      -b 1 \
+      -bs 10 \
+      -f prompts/prompt.md
+  done
+done


### PR DESCRIPTION
small changes to vllm runner:
- changed tensor parallelism to 1 always (ie disabled) as we generally saw better results [here](https://docs.google.com/spreadsheets/d/1wDkn4IsXyVUOyJrfY1BQMfeFExt872vmoHflv09Nnlc/edit#gid=0)
- remove tqdm from vllm's `.generate` as it was cluttering up the output.
also added a simple script for evaluating checkpoints in a directory sequentially.