### PR TITLE
Usability improvements

### DIFF
--- a/run_checkpoints.sh
+++ b/run_checkpoints.sh
@@ -1,6 +1,6 @@
 #!/bin/zsh
 
-model_names=("sqlcoder_8b_fullft_ds_008_llama3_mgn1_b1_0900_b2_0990")
+model_names=("sqlcoder_8b_fullft_ds_005_llama3_mgn1_b1_0900_b2_0990")
 
 # Loop over model names
 for model_name in "${model_names[@]}"; do
@@ -34,7 +34,16 @@ for model_name in "${model_names[@]}"; do
     done
 
     # then run sql-eval
-    python3 main.py -db postgres -q "data/questions_gen_postgres.csv" "data/instruct_basic_postgres.csv" "data/instruct_advanced_postgres.csv" -o "results/${model_name}/c${checkpoint_num}_v1_api.csv" "results/${model_name}/c${checkpoint_num}_v1_basic.csv" "results/${model_name}/c${checkpoint_num}_v1_advanced.csv" -g api -b 1 -f prompts/prompt.md --api_url "http://localhost:8080/generate" --api_type "vllm" -p 10 -c 0
+    python3 main.py -db postgres \
+      -q "data/questions_gen_postgres.csv" "data/instruct_basic_postgres.csv" "data/instruct_advanced_postgres.csv" "data/idk.csv" \
+      -o "results/${model_name}/c${checkpoint_num}_api_v1.csv" "results/${model_name}/c${checkpoint_num}_api_basic.csv" "results/${model_name}/c${checkpoint_num}_api_advanced.csv" "results/${model_name}/c${checkpoint_num}_api_idk.csv" \
+      -g api \
+      -b 1 \
+      -c 0 \
+      -f prompts/prompt.md \
+      --api_url "http://localhost:8080/generate" \
+      --api_type "vllm" \
+      -p 10
     # finally, kill the api server
     pkill -9 -f utils/api_server.py
   done

--- a/utils/api_server.py
+++ b/utils/api_server.py
@@ -52,7 +52,7 @@ async def generate(request: Request) -> Response:
     request_id = random_uuid()
     tokenizer = await engine.get_tokenizer()
     prompt_token_ids = tokenizer.encode(text=prompt, add_special_tokens=False)
-    print(f"prompt_token_ids: {prompt_token_ids}")
+    # print(f"prompt_token_ids: {prompt_token_ids}")
     if prompt_token_ids[0] != tokenizer.bos_token_id:
         prompt_token_ids = [tokenizer.bos_token_id] + prompt_token_ids
 

--- a/utils/dialects.py
+++ b/utils/dialects.py
@@ -12,10 +12,7 @@ import asyncio
 import json
 import pandas as pd
 import logging
-import mysql.connector
-from mysql.connector import errorcode
 import sqlite3
-import pyodbc
 
 # Suppress all logs from sqlglot
 logging.getLogger("sqlglot").setLevel(logging.CRITICAL)
@@ -508,6 +505,9 @@ def create_mysql_db(creds, db_name, table_metadata_string_test, row_idx):
     """
     Create a test MySQL database and tables from the table_metadata_string
     """
+    import mysql.connector
+    from mysql.connector import errorcode
+
     test_db_name = f"test{row_idx}_" + db_name
     try:
         conn = mysql.connector.connect(**creds["mysql"])
@@ -545,11 +545,12 @@ def delete_mysql_db(db_name, row_idx):
     """
     Delete a test MySQL database
     """
+    import mysql.connector
+    from mysql.connector import errorcode
 
     test_db_name = f"test{row_idx}_" + db_name
 
     # Delete the test database
-
     try:
         conn = mysql.connector.connect(**creds["mysql"])
         cursor = conn.cursor()
@@ -574,6 +575,8 @@ def test_valid_md_mysql(sql_test_list, db_name, table_metadata_string_test, row_
     Test the validity of the metadata and sql in MySQL.
     This will create a test dataset and tables, run the sql and delete the test dataset.
     """
+    import mysql.connector
+
     validity_tuple_list = []
     test_db = f"test{row_idx}_{db_name}"
     # create a test db
@@ -633,7 +636,6 @@ def test_valid_md_mysql_concurr(df, sql_list_col, table_metadata_col):
     """
     Run test_valid_md_mysql concurrently on a DataFrame
     """
-
     futures_to_index = {}
 
     with concurrent.futures.ThreadPoolExecutor() as executor:
@@ -858,6 +860,8 @@ def create_tsql_db(creds, db_name, table_metadata_string_test, row_idx):
     """
     Create a test T-SQL database and tables from the table_metadata_string
     """
+    import pyodbc
+
     test_db_name = f"test{row_idx}_" + db_name
     try:
         with pyodbc.connect(
@@ -903,6 +907,8 @@ def delete_tsql_db(db_name, row_idx):
     """
     Delete a test T-SQL database
     """
+    import pyodbc
+
     test_db_name = f"test{row_idx}_{db_name}"
     try:
         with pyodbc.connect(


### PR DESCRIPTION
- api server to not print prompt token ids
- postpone imports in dialects.py to avoid importing unless we're using the specific db_type and actually triggering the validity checks