### PR TITLE
SQLite SERIAL, drop valid/err_msg cols

### DIFF
--- a/eval/api_runner.py
+++ b/eval/api_runner.py
@@ -282,7 +282,7 @@ def run_api_eval(args):
 
         if logprobs:
             print(
-                f"Writing logprobs to JSON file at {output_file.replace('.csv', '.json')}"
+                f"Writing logprobs to JSON file at eval-visualizer/public/{output_file.split('/')[-1].replace('.csv', '.json')}"
             )
             results = output_df.to_dict("records")
             with open(

--- a/translate_sql_dialect.py
+++ b/translate_sql_dialect.py
@@ -380,6 +380,10 @@ cols = list(merged_df.columns)
 cols = first_cols + [col for col in cols if col not in first_cols]
 merged_df = merged_df[cols]
 
+# drop valid and err_msg cols if n_invalid = 0
+if n_invalid == 0:
+    merged_df.drop(columns=["valid", "err_msg"], inplace=True)
+
 # save to csv
 merged_df.to_csv(output_file, index=False)
 print(f"Saved to {output_file}")

--- a/utils/dialects.py
+++ b/utils/dialects.py
@@ -691,6 +691,7 @@ def ddl_to_sqlite(ddl, db_type, db_name, row_idx):
     translated = ddl_to_dialect(ddl, db_type, "sqlite")
     translated = ddl_remove_schema(translated)
     translated = translated.replace(")\nCREATE", ");\nCREATE")
+    translated = re.sub(r"SERIAL", "INTEGER PRIMARY KEY", translated)
     translated += ";"
     return translated, translated
 


### PR DESCRIPTION
Small fixes:
- Replaced SERIAL data type for sqlite ddl statements as it's not a valid data type
- Drop valid and err_msg columns in final df for translation if we're sure that there are no invalid rows that need manual correction
- Edited printed path for where logprobs are stored