### PR TITLE
Add CoT

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,7 @@ You can use the following flags in the command line to change the configurations
 | -c, --num_columns        | Number of columns, default 20. To not prune the columns, set it to 0. |
 | -s, --shuffle_metadata   | Shuffle metadata, default False. This shuffles the order of the tables within the schema and the order of the columns within each table but does not shift columns between tables (to preserve the structure of the database). |
 | -k, --k_shot             | Used when you want to include k-shot examples in your prompt. Make sure that the column 'k_shot_prompt' exists in your questions_file.                                                                                                    |
+| --cot_table_alias        | Used when you want to include chain-of-thought instructions before the actual sql generation. Make sure that the placeholder '{cot_instructions}' exists in your prompt file. |                                                                                                    |
 
 ### Execution-related parameters
 

--- a/eval/anthropic_runner.py
+++ b/eval/anthropic_runner.py
@@ -20,6 +20,7 @@ def run_anthropic_eval(args):
     num_questions = args.num_questions
     k_shot = args.k_shot
     db_type = args.db_type
+    cot_table_alias = args.cot_table_alias
 
     for questions_file, prompt_file, output_file in zip(
         questions_file_list, prompt_file_list, output_file_list
@@ -31,7 +32,7 @@ def run_anthropic_eval(args):
             f"Using {'all' if num_questions is None else num_questions} question(s) from {questions_file}"
         )
         question_query_df = prepare_questions_df(
-            questions_file, db_type, num_questions, k_shot
+            questions_file, db_type, num_questions, k_shot, cot_table_alias
         )
         input_rows = question_query_df.to_dict("records")
         output_rows = []
@@ -62,6 +63,7 @@ def run_anthropic_eval(args):
                     table_metadata_string=row["table_metadata_string"],
                     prev_invalid_sql=row["prev_invalid_sql"],
                     prev_error_msg=row["prev_error_msg"],
+                    cot_instructions=row["cot_instructions"],
                     columns_to_keep=args.num_columns,
                     shuffle=args.shuffle_metadata,
                 )

--- a/eval/api_runner.py
+++ b/eval/api_runner.py
@@ -178,6 +178,7 @@ def run_api_eval(args):
     db_type = args.db_type
     decimal_points = args.decimal_points
     logprobs = args.logprobs
+    cot_table_alias = args.cot_table_alias
 
     if logprobs:
         # check that the eval-visualizer/public directory exists
@@ -199,7 +200,9 @@ def run_api_eval(args):
         print(
             f"Using {'all' if num_questions is None else num_questions} question(s) from {questions_file}"
         )
-        df = prepare_questions_df(questions_file, db_type, num_questions, k_shot)
+        df = prepare_questions_df(
+            questions_file, db_type, num_questions, k_shot, cot_table_alias
+        )
         # create a prompt for each question
         df["prompt"] = df[
             [
@@ -216,6 +219,7 @@ def run_api_eval(args):
                 "query_0",
                 "question_1",
                 "query_1",
+                "cot_instructions",
             ]
         ].apply(
             lambda row: generate_prompt(
@@ -233,6 +237,7 @@ def run_api_eval(args):
                 row["query_0"],
                 row["question_1"],
                 row["query_1"],
+                row["cot_instructions"],
                 public_data,
                 args.num_columns,
                 args.shuffle_metadata,

--- a/eval/bedrock_runner.py
+++ b/eval/bedrock_runner.py
@@ -98,6 +98,7 @@ def run_bedrock_eval(args):
     db_type = args.db_type
     decimal_points = args.decimal_points
     model_id = args.model
+    cot_table_alias = args.cot_table_alias
 
     for questions_file, prompt_file, output_file in zip(
         questions_file_list, prompt_file_list, output_file_list
@@ -108,7 +109,9 @@ def run_bedrock_eval(args):
         print(
             f"Using {'all' if num_questions is None else num_questions} question(s) from {questions_file}"
         )
-        df = prepare_questions_df(questions_file, db_type, num_questions, k_shot)
+        df = prepare_questions_df(
+            questions_file, db_type, num_questions, k_shot, cot_table_alias
+        )
         # create a prompt for each question
         df["prompt"] = df[
             [
@@ -125,6 +128,7 @@ def run_bedrock_eval(args):
                 "query_0",
                 "question_1",
                 "query_1",
+                "cot_instructions",
             ]
         ].apply(
             lambda row: generate_prompt(
@@ -142,6 +146,7 @@ def run_bedrock_eval(args):
                 row["query_0"],
                 row["question_1"],
                 row["query_1"],
+                row["cot_instructions"],
                 public_data,
                 args.num_columns,
                 args.shuffle_metadata,

--- a/eval/gemini_runner.py
+++ b/eval/gemini_runner.py
@@ -109,6 +109,7 @@ def run_gemini_eval(args):
     k_shot = args.k_shot
     max_workers = args.parallel_threads
     db_type = args.db_type
+    cot_table_alias = args.cot_table_alias
 
     for questions_file, prompt_file, output_file in zip(
         questions_file_list, prompt_file_list, output_file_list
@@ -119,7 +120,9 @@ def run_gemini_eval(args):
         print(
             f"Using {'all' if num_questions is None else num_questions} question(s) from {questions_file}"
         )
-        df = prepare_questions_df(questions_file, db_type, num_questions, k_shot)
+        df = prepare_questions_df(
+            questions_file, db_type, num_questions, k_shot, cot_table_alias
+        )
         # create a prompt for each question
         df["prompt"] = df[
             [
@@ -136,6 +139,7 @@ def run_gemini_eval(args):
                 "query_0",
                 "question_1",
                 "query_1",
+                "cot_instructions",
             ]
         ].apply(
             lambda row: generate_prompt(
@@ -149,6 +153,7 @@ def run_gemini_eval(args):
                 row["table_metadata_string"],
                 row["prev_invalid_sql"],
                 row["prev_error_msg"],
+                row["cot_instructions"],
                 public_data,
                 args.num_columns,
                 args.shuffle_metadata,

--- a/eval/hf_runner.py
+++ b/eval/hf_runner.py
@@ -76,6 +76,7 @@ def run_hf_eval(args):
     k_shot = args.k_shot
     db_type = args.db_type
     num_beams = args.num_beams
+    cot_table_alias = args.cot_table_alias
 
     if model_name is None and adapter_path is None:
         raise ValueError(
@@ -110,7 +111,9 @@ def run_hf_eval(args):
         print(
             f"Using {'all' if num_questions is None else num_questions} question(s) from {questions_file}"
         )
-        df = prepare_questions_df(questions_file, db_type, num_questions, k_shot)
+        df = prepare_questions_df(
+            questions_file, db_type, num_questions, k_shot, cot_table_alias
+        )
         # create a prompt for each question
         df["prompt"] = df[
             [
@@ -127,6 +130,7 @@ def run_hf_eval(args):
                 "query_0",
                 "question_1",
                 "query_1",
+                "cot_instructions",
             ]
         ].apply(
             lambda row: generate_prompt(
@@ -144,6 +148,7 @@ def run_hf_eval(args):
                 row["query_0"],
                 row["question_1"],
                 row["query_1"],
+                row["cot_instructions"],
                 public_data,
                 args.num_columns,
                 args.shuffle_metadata,

--- a/eval/llama_cpp_runner.py
+++ b/eval/llama_cpp_runner.py
@@ -72,6 +72,7 @@ def run_llama_cpp_eval(args):
     k_shot = args.k_shot
     max_workers = args.parallel_threads
     db_type = args.db_type
+    cot_table_alias = args.cot_table_alias
 
     llm = Llama(model_path=model_path, n_gpu_layers=-1, n_ctx=2048)
 
@@ -84,7 +85,9 @@ def run_llama_cpp_eval(args):
         print(
             f"Using {'all' if num_questions is None else num_questions} question(s) from {questions_file}"
         )
-        df = prepare_questions_df(questions_file, db_type, num_questions, k_shot)
+        df = prepare_questions_df(
+            questions_file, db_type, num_questions, k_shot, cot_table_alias
+        )
         # create a prompt for each question
         df["prompt"] = df[
             [
@@ -101,6 +104,7 @@ def run_llama_cpp_eval(args):
                 "query_0",
                 "question_1",
                 "query_1",
+                "cot_instructions",
             ]
         ].apply(
             lambda row: generate_prompt(
@@ -118,6 +122,7 @@ def run_llama_cpp_eval(args):
                 row["query_0"],
                 row["question_1"],
                 row["query_1"],
+                row["cot_instructions"],
                 public_data,
                 args.num_columns,
                 args.shuffle_metadata,

--- a/eval/mistral_runner.py
+++ b/eval/mistral_runner.py
@@ -138,6 +138,7 @@ def run_mistral_eval(args):
     k_shot = args.k_shot
     max_workers = args.parallel_threads
     db_type = args.db_type
+    cot_table_alias = args.cot_table_alias
 
     for questions_file, prompt_file, output_file in zip(
         questions_file_list, prompt_file_list, output_file_list
@@ -148,7 +149,9 @@ def run_mistral_eval(args):
         print(
             f"Using {'all' if num_questions is None else num_questions} question(s) from {questions_file}"
         )
-        df = prepare_questions_df(questions_file, db_type, num_questions, k_shot)
+        df = prepare_questions_df(
+            questions_file, db_type, num_questions, k_shot, cot_table_alias
+        )
         # create a prompt for each question
         df["prompt"] = df[
             [
@@ -165,6 +168,7 @@ def run_mistral_eval(args):
                 "query_0",
                 "question_1",
                 "query_1",
+                "cot_instructions",
             ]
         ].apply(
             lambda row: generate_prompt(
@@ -182,6 +186,7 @@ def run_mistral_eval(args):
                 row["query_0"],
                 row["question_1"],
                 row["query_1"],
+                row["cot_instructions"],
                 public_data,
                 args.num_columns,
                 args.shuffle_metadata,

--- a/eval/mlx_runner.py
+++ b/eval/mlx_runner.py
@@ -65,6 +65,7 @@ def run_mlx_eval(args):
     output_file_list = args.output_file
     k_shot = args.k_shot
     db_type = args.db_type
+    cot_table_alias = args.cot_table_alias
 
     model, tokenizer = load(model_path)
 
@@ -77,7 +78,9 @@ def run_mlx_eval(args):
         print(
             f"Using {'all' if num_questions is None else num_questions} question(s) from {questions_file}"
         )
-        df = prepare_questions_df(questions_file, db_type, num_questions, k_shot)
+        df = prepare_questions_df(
+            questions_file, db_type, num_questions, k_shot, cot_table_alias
+        )
         # create a prompt for each question
         df["prompt"] = df[
             [
@@ -94,6 +97,7 @@ def run_mlx_eval(args):
                 "query_0",
                 "question_1",
                 "query_1",
+                "cot_instructions",
             ]
         ].apply(
             lambda row: generate_prompt(
@@ -111,6 +115,7 @@ def run_mlx_eval(args):
                 row["query_0"],
                 row["question_1"],
                 row["query_1"],
+                row["cot_instructions"],
                 public_data,
                 args.num_columns,
                 args.shuffle_metadata,

--- a/eval/openai_runner.py
+++ b/eval/openai_runner.py
@@ -21,6 +21,7 @@ def run_openai_eval(args):
     num_questions = args.num_questions
     k_shot = args.k_shot
     db_type = args.db_type
+    cot_table_alias = args.cot_table_alias
 
     for questions_file, prompt_file, output_file in zip(
         questions_file_list, prompt_file_list, output_file_list
@@ -32,7 +33,7 @@ def run_openai_eval(args):
             f"Using {'all' if num_questions is None else num_questions} question(s) from {questions_file}"
         )
         question_query_df = prepare_questions_df(
-            questions_file, db_type, num_questions, k_shot
+            questions_file, db_type, num_questions, k_shot, cot_table_alias
         )
         input_rows = question_query_df.to_dict("records")
         output_rows = []
@@ -63,6 +64,7 @@ def run_openai_eval(args):
                     table_metadata_string=row["table_metadata_string"],
                     prev_invalid_sql=row["prev_invalid_sql"],
                     prev_error_msg=row["prev_error_msg"],
+                    cot_instructions=row["cot_instructions"],
                     columns_to_keep=args.num_columns,
                     shuffle=args.shuffle_metadata,
                 )

--- a/eval/vllm_runner.py
+++ b/eval/vllm_runner.py
@@ -26,6 +26,7 @@ def run_vllm_eval(args):
     num_beams = args.num_beams
     k_shot = args.k_shot
     db_type = args.db_type
+    cot_table_alias = args.cot_table_alias
 
     # initialize model only once as it takes a while
     print(f"Preparing {model_name}")
@@ -58,7 +59,9 @@ def run_vllm_eval(args):
         print(
             f"Using {'all' if num_questions is None else num_questions} question(s) from {questions_file}"
         )
-        df = prepare_questions_df(questions_file, db_type, num_questions, k_shot)
+        df = prepare_questions_df(
+            questions_file, db_type, num_questions, k_shot, cot_table_alias
+        )
         # create a prompt for each question
         df["prompt"] = df[
             [
@@ -75,6 +78,7 @@ def run_vllm_eval(args):
                 "query_0",
                 "question_1",
                 "query_1",
+                "cot_instructions",
             ]
         ].apply(
             lambda row: generate_prompt(
@@ -92,6 +96,7 @@ def run_vllm_eval(args):
                 row["query_0"],
                 row["question_1"],
                 row["query_1"],
+                row["cot_instructions"],
                 public_data,
                 args.num_columns,
                 args.shuffle_metadata,

--- a/main.py
+++ b/main.py
@@ -24,6 +24,7 @@ if __name__ == "__main__":
     parser.add_argument("-c", "--num_columns", type=int, default=20)
     parser.add_argument("-s", "--shuffle_metadata", action="store_true")
     parser.add_argument("-k", "--k_shot", action="store_true")
+    parser.add_argument("--cot_table_alias", action="store_true")
     # execution-related parameters
     parser.add_argument("-o", "--output_file", nargs="+", type=str, required=True)
     parser.add_argument("-p", "--parallel_threads", type=int, default=5)
@@ -44,7 +45,7 @@ if __name__ == "__main__":
 
     # check that questions_file matches db_type
     for questions_file in args.questions_file:
-        if args.db_type not in questions_file:
+        if args.db_type not in questions_file and questions_file != "data/idk.csv":
             print(
                 f"WARNING: Check that questions_file {questions_file} is compatible with db_type {args.db_type}"
             )

--- a/prompts/prompt_anthropic.md
+++ b/prompts/prompt_anthropic.md
@@ -8,5 +8,5 @@ This query will run on a database whose schema is represented in this string:
 {table_metadata_string}
 {k_shot_prompt}
 ### Response:
-Given the database schema, here is the SQL query that answers `{user_question}`:
+{cot_instructions}Given the database schema, here is the SQL query that answers `{user_question}`:
 ```sql

--- a/prompts/prompt_cot.md
+++ b/prompts/prompt_cot.md
@@ -1,0 +1,9 @@
+<|start_header_id|>user<|end_header_id|>
+
+Generate a SQL query to answer this question: `{user_question}`
+{instructions}{glossary}
+DDL statements:
+{table_metadata_string}
+
+{cot_instructions}Generate a valid SQL query that answers the question `{user_question}`, and only references the tables and columns in the DDL statements.<|eot_id|><|start_header_id|>assistant<|end_header_id|>
+

--- a/prompts/prompt_openai.md
+++ b/prompts/prompt_openai.md
@@ -8,5 +8,5 @@ This query will run on a database whose schema is represented in this string:
 {table_metadata_string}
 {k_shot_prompt}
 ### Response:
-Given the database schema, here is the SQL query that answers `{user_question}`:
+{cot_instructions}Given the database schema, here is the SQL query that answers `{user_question}`:
 ```sql

--- a/query_generators/anthropic.py
+++ b/query_generators/anthropic.py
@@ -86,6 +86,7 @@ class AnthropicQueryGenerator(QueryGenerator):
         table_metadata_string: str,
         prev_invalid_sql: str,
         prev_error_msg: str,
+        cot_instructions: str,
         columns_to_keep: int,
         shuffle: bool,
     ) -> dict:
@@ -115,6 +116,7 @@ class AnthropicQueryGenerator(QueryGenerator):
             glossary=glossary,
             prev_invalid_sql=prev_invalid_sql,
             prev_error_msg=prev_error_msg,
+            cot_instructions=cot_instructions,
         )
         function_to_run = self.get_completion
         package = prompt

--- a/query_generators/openai.py
+++ b/query_generators/openai.py
@@ -120,6 +120,7 @@ class OpenAIQueryGenerator(QueryGenerator):
         table_metadata_string: str,
         prev_invalid_sql: str,
         prev_error_msg: str,
+        cot_instructions: str,
         columns_to_keep: int,
         shuffle: bool,
     ) -> dict:
@@ -170,6 +171,7 @@ class OpenAIQueryGenerator(QueryGenerator):
                 glossary=glossary,
                 prev_invalid_sql=prev_invalid_sql,
                 prev_error_msg=prev_error_msg,
+                cot_instructions=cot_instructions,
             )
 
             messages = []
@@ -185,6 +187,7 @@ class OpenAIQueryGenerator(QueryGenerator):
                 glossary=glossary,
                 prev_invalid_sql=prev_invalid_sql,
                 prev_error_msg=prev_error_msg,
+                cot_instructions=cot_instructions,
             )
         function_to_run = None
         package = None

--- a/run_checkpoints_cot.sh
+++ b/run_checkpoints_cot.sh
@@ -1,8 +1,8 @@
 #!/bin/zsh
 
 model_names=("sqlcoder_8b_fullft_ds_003_llama3_mgn1_b1_0900_b2_0990")
-PORT=8082 # avoid 8081 as it's used by nginx
-export CUDA_VISIBLE_DEVICES=0 # set gpu you want to use (just 1 will do)
+PORT=8083 # avoid 8081 as it's used by nginx
+export CUDA_VISIBLE_DEVICES=1 # set gpu you want to use (just 1 will do)
 
 # Loop over model names
 for model_name in "${model_names[@]}"; do
@@ -37,15 +37,16 @@ for model_name in "${model_names[@]}"; do
 
     # then run sql-eval
     python3 main.py -db postgres \
-      -f prompts/prompt.md \
+      -f prompts/prompt_cot.md \
       -q "data/questions_gen_postgres.csv" "data/instruct_basic_postgres.csv" "data/instruct_advanced_postgres.csv" "data/idk.csv" \
-      -o "results/${model_name}/c${checkpoint_num}_api_v1.csv" "results/${model_name}/c${checkpoint_num}_api_basic.csv" "results/${model_name}/c${checkpoint_num}_api_advanced.csv" "results/${model_name}/c${checkpoint_num}_api_idk.csv" \
+      -o "results/${model_name}/c${checkpoint_num}_api_v1_cot.csv" "results/${model_name}/c${checkpoint_num}_api_basic_cot.csv" "results/${model_name}/c${checkpoint_num}_api_advanced_cot.csv" "results/${model_name}/c${checkpoint_num}_api_idk_cot.csv" \
       -g api \
       -b 1 \
       -c 0 \
       --api_url "http://localhost:${PORT}/generate" \
       --api_type "vllm" \
-      -p 10
+      -p 10 \
+      --cot_table_alias
     # finally, kill the api server
     pkill -9 -f utils/api_server.py
   done

--- a/utils/gen_prompt.py
+++ b/utils/gen_prompt.py
@@ -71,6 +71,7 @@ def generate_prompt(
     query_0="",
     question_1="",
     query_1="",
+    cot_instructions="",
     public_data=True,
     columns_to_keep=40,
     shuffle_metadata=False,
@@ -173,5 +174,6 @@ def generate_prompt(
         query_0=query_0,
         question_1=question_1,
         query_1=query_1,
+        cot_instructions=cot_instructions,
     )
     return prompt

--- a/utils/questions.py
+++ b/utils/questions.py
@@ -7,6 +7,7 @@ def prepare_questions_df(
     db_type: str,
     num_questions: Optional[int] = None,
     k_shot: bool = False,
+    cot_table_alias: bool = False,
 ):
     question_query_df = pd.read_csv(questions_file, nrows=num_questions)
     question_query_df["db_type"] = db_type
@@ -111,5 +112,13 @@ def prepare_questions_df(
         question_query_df["query_1"] = question_query_df["query_1"].fillna("")
     else:
         question_query_df["query_1"] = ""
+
+    # add all cot instructions to the `cot_instructions` column
+    if cot_table_alias:
+        question_query_df["cot_instructions"] = (
+            "List the table aliases for each table as comments, starting with the most relevant tables to the question."
+        )
+    else:
+        question_query_df["cot_instructions"] = ""
 
     return question_query_df


### PR DESCRIPTION
- Add cot table alias option for running evals. Currently this just appends a standard instruction before the final instruction to generate the SQL output.
- Wire up the passing of `cot_instructions` through each runner
- Add cot_instructions to various prompts
- Added modified script `run_checkpoints_cot.sh` for running checkpoints with the cot prompt. We also parameterize both shell scripts to use different ports and cuda devices to allow parallel evaluations if the host has > 1 gpu.