### PR TITLE
Small pesky bugs found while examining dialect exec errors

### DIFF
--- a/eval/api_runner.py
+++ b/eval/api_runner.py
@@ -83,7 +83,7 @@ def process_row(
         row["tokens_used"] = None
         if logprobs:
             row["logprobs"] = []
-        
+
         return row
     end_time = time()
     logprobs = []

--- a/eval/api_runner.py
+++ b/eval/api_runner.py
@@ -80,6 +80,10 @@ def process_row(
         row["correct"] = 0
         row["error_db_exec"] = 1
         row["error_msg"] = "API TIMEOUT"
+        row["tokens_used"] = None
+        if logprobs:
+            row["logprobs"] = []
+        
         return row
     end_time = time()
     logprobs = []
@@ -105,6 +109,9 @@ def process_row(
             generated_query = generated_query.split("[SQL]", 1)[1].strip()
         else:
             generated_query = generated_query.strip()
+
+    # remove extra spaces around brackets especially for MySQL
+    generated_query = generated_query.replace(" ( ", "(").replace(" )", ")")
 
     if "logprobs" in r.json():
         logprobs = r.json()["logprobs"]

--- a/eval/eval.py
+++ b/eval/eval.py
@@ -516,6 +516,7 @@ def query_tsql_db(
             with conn.cursor() as cursor:
                 cursor.execute(query)
                 results = cursor.fetchall()
+                results = [list(row) for row in results]
                 colnames = [desc[0] for desc in cursor.description]
                 # make into a dataframe
                 df = pd.DataFrame(results, columns=colnames)


### PR DESCRIPTION
- Removed spaces before brackets post sql generation as MySQL cannot parse with the additional spaces
- Fixed a persistent T-SQL exec error stemming from `query_tsql_db` that would not form the dataframe due to shape mismatch.
- Fixed process_row to include keys `tokens_used` and `logprobs` when post request times out. Previously it would produce NaNs in the final json file, which could not be read by the eval_visualizer.