### PR TITLE
Dynamically add table aliases without an LLM + de-duplicate columns in pandas

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,7 +371,7 @@ You can use the following flags in the command line to change the configurations
 | -c, --num_columns        | Number of columns, default 20. To not prune the columns, set it to 0. |
 | -s, --shuffle_metadata   | Shuffle metadata, default False. This shuffles the order of the tables within the schema and the order of the columns within each table but does not shift columns between tables (to preserve the structure of the database). |
 | -k, --k_shot             | Used when you want to include k-shot examples in your prompt. Make sure that the column 'k_shot_prompt' exists in your questions_file.                                                                                                    |
-| --cot_table_alias        | Used when you want to include chain-of-thought instructions before the actual sql generation. Make sure that the placeholder '{cot_instructions}' exists in your prompt file. |                                                                                                    |
+| --cot_table_alias        | Used when you want to include chain-of-thought instructions before the actual sql generation. Allowed values are `instruct` and `pregen`. If using `instruct`, make sure that the placeholder '{cot_instructions}' exists in your prompt file. |                                                                                                    |
 
 ### Execution-related parameters
 

--- a/eval/api_runner.py
+++ b/eval/api_runner.py
@@ -211,24 +211,7 @@ def run_api_eval(args):
             questions_file, db_type, num_questions, k_shot, cot_table_alias
         )
         # create a prompt for each question
-        df["prompt"] = df[
-            [
-                "question",
-                "db_name",
-                "db_type",
-                "instructions",
-                "k_shot_prompt",
-                "glossary",
-                "table_metadata_string",
-                "prev_invalid_sql",
-                "prev_error_msg",
-                "question_0",
-                "query_0",
-                "question_1",
-                "query_1",
-                "cot_instructions",
-            ]
-        ].apply(
+        df["prompt"] = df.apply(
             lambda row: generate_prompt(
                 prompt_file,
                 row["question"],
@@ -245,6 +228,7 @@ def run_api_eval(args):
                 row["question_1"],
                 row["query_1"],
                 row["cot_instructions"],
+                row["cot_pregen"],
                 public_data,
                 args.num_columns,
                 args.shuffle_metadata,

--- a/eval/bedrock_runner.py
+++ b/eval/bedrock_runner.py
@@ -113,24 +113,7 @@ def run_bedrock_eval(args):
             questions_file, db_type, num_questions, k_shot, cot_table_alias
         )
         # create a prompt for each question
-        df["prompt"] = df[
-            [
-                "question",
-                "db_name",
-                "db_type",
-                "instructions",
-                "k_shot_prompt",
-                "glossary",
-                "table_metadata_string",
-                "prev_invalid_sql",
-                "prev_error_msg",
-                "question_0",
-                "query_0",
-                "question_1",
-                "query_1",
-                "cot_instructions",
-            ]
-        ].apply(
+        df["prompt"] = df.apply(
             lambda row: generate_prompt(
                 prompt_file,
                 row["question"],
@@ -147,6 +130,7 @@ def run_bedrock_eval(args):
                 row["question_1"],
                 row["query_1"],
                 row["cot_instructions"],
+                row["cot_pregen"],
                 public_data,
                 args.num_columns,
                 args.shuffle_metadata,

--- a/eval/eval.py
+++ b/eval/eval.py
@@ -12,16 +12,20 @@ import collections
 
 LIKE_PATTERN = r"LIKE[\s\S]*'"
 
+
 def deduplicate_columns(df: pd.DataFrame) -> pd.DataFrame:
     cols = df.columns.tolist()
     if len(cols) != len(set(cols)):
-        duplicates = [item for item, count in collections.Counter(cols).items() if count > 1]
+        duplicates = [
+            item for item, count in collections.Counter(cols).items() if count > 1
+        ]
         for dup in duplicates:
             indices = [i for i, x in enumerate(cols) if x == dup]
             for i in indices:
                 cols[i] = f"{dup}_{i}"
         df.columns = cols
     return df
+
 
 def normalize_table(
     df: pd.DataFrame, query_category: str, question: str, sql: str = None

--- a/eval/gemini_runner.py
+++ b/eval/gemini_runner.py
@@ -124,24 +124,7 @@ def run_gemini_eval(args):
             questions_file, db_type, num_questions, k_shot, cot_table_alias
         )
         # create a prompt for each question
-        df["prompt"] = df[
-            [
-                "question",
-                "db_name",
-                "db_type",
-                "instructions",
-                "k_shot_prompt",
-                "glossary",
-                "table_metadata_string",
-                "prev_invalid_sql",
-                "prev_error_msg",
-                "question_0",
-                "query_0",
-                "question_1",
-                "query_1",
-                "cot_instructions",
-            ]
-        ].apply(
+        df["prompt"] = df.apply(
             lambda row: generate_prompt(
                 prompt_file,
                 row["question"],
@@ -154,6 +137,7 @@ def run_gemini_eval(args):
                 row["prev_invalid_sql"],
                 row["prev_error_msg"],
                 row["cot_instructions"],
+                row["cot_pregen"],
                 public_data,
                 args.num_columns,
                 args.shuffle_metadata,

--- a/eval/hf_runner.py
+++ b/eval/hf_runner.py
@@ -115,24 +115,7 @@ def run_hf_eval(args):
             questions_file, db_type, num_questions, k_shot, cot_table_alias
         )
         # create a prompt for each question
-        df["prompt"] = df[
-            [
-                "question",
-                "db_name",
-                "db_type",
-                "instructions",
-                "k_shot_prompt",
-                "glossary",
-                "table_metadata_string",
-                "prev_invalid_sql",
-                "prev_error_msg",
-                "question_0",
-                "query_0",
-                "question_1",
-                "query_1",
-                "cot_instructions",
-            ]
-        ].apply(
+        df["prompt"] = df.apply(
             lambda row: generate_prompt(
                 prompt_file,
                 row["question"],
@@ -149,6 +132,7 @@ def run_hf_eval(args):
                 row["question_1"],
                 row["query_1"],
                 row["cot_instructions"],
+                row["cot_pregen"],
                 public_data,
                 args.num_columns,
                 args.shuffle_metadata,

--- a/eval/llama_cpp_runner.py
+++ b/eval/llama_cpp_runner.py
@@ -89,24 +89,7 @@ def run_llama_cpp_eval(args):
             questions_file, db_type, num_questions, k_shot, cot_table_alias
         )
         # create a prompt for each question
-        df["prompt"] = df[
-            [
-                "question",
-                "db_name",
-                "db_type",
-                "instructions",
-                "k_shot_prompt",
-                "glossary",
-                "table_metadata_string",
-                "prev_invalid_sql",
-                "prev_error_msg",
-                "question_0",
-                "query_0",
-                "question_1",
-                "query_1",
-                "cot_instructions",
-            ]
-        ].apply(
+        df["prompt"] = df.apply(
             lambda row: generate_prompt(
                 prompt_file,
                 row["question"],
@@ -123,6 +106,7 @@ def run_llama_cpp_eval(args):
                 row["question_1"],
                 row["query_1"],
                 row["cot_instructions"],
+                row["cot_pregen"],
                 public_data,
                 args.num_columns,
                 args.shuffle_metadata,

--- a/eval/mistral_runner.py
+++ b/eval/mistral_runner.py
@@ -153,24 +153,7 @@ def run_mistral_eval(args):
             questions_file, db_type, num_questions, k_shot, cot_table_alias
         )
         # create a prompt for each question
-        df["prompt"] = df[
-            [
-                "question",
-                "db_name",
-                "db_type",
-                "instructions",
-                "k_shot_prompt",
-                "glossary",
-                "table_metadata_string",
-                "prev_invalid_sql",
-                "prev_error_msg",
-                "question_0",
-                "query_0",
-                "question_1",
-                "query_1",
-                "cot_instructions",
-            ]
-        ].apply(
+        df["prompt"] = df.apply(
             lambda row: generate_prompt(
                 prompt_file,
                 row["question"],
@@ -187,6 +170,7 @@ def run_mistral_eval(args):
                 row["question_1"],
                 row["query_1"],
                 row["cot_instructions"],
+                row["cot_pregen"],
                 public_data,
                 args.num_columns,
                 args.shuffle_metadata,

--- a/eval/mlx_runner.py
+++ b/eval/mlx_runner.py
@@ -82,24 +82,7 @@ def run_mlx_eval(args):
             questions_file, db_type, num_questions, k_shot, cot_table_alias
         )
         # create a prompt for each question
-        df["prompt"] = df[
-            [
-                "question",
-                "db_name",
-                "db_type",
-                "instructions",
-                "k_shot_prompt",
-                "glossary",
-                "table_metadata_string",
-                "prev_invalid_sql",
-                "prev_error_msg",
-                "question_0",
-                "query_0",
-                "question_1",
-                "query_1",
-                "cot_instructions",
-            ]
-        ].apply(
+        df["prompt"] = df.apply(
             lambda row: generate_prompt(
                 prompt_file,
                 row["question"],
@@ -116,6 +99,7 @@ def run_mlx_eval(args):
                 row["question_1"],
                 row["query_1"],
                 row["cot_instructions"],
+                row["cot_pregen"],
                 public_data,
                 args.num_columns,
                 args.shuffle_metadata,

--- a/eval/vllm_runner.py
+++ b/eval/vllm_runner.py
@@ -63,24 +63,7 @@ def run_vllm_eval(args):
             questions_file, db_type, num_questions, k_shot, cot_table_alias
         )
         # create a prompt for each question
-        df["prompt"] = df[
-            [
-                "question",
-                "db_name",
-                "db_type",
-                "instructions",
-                "k_shot_prompt",
-                "glossary",
-                "table_metadata_string",
-                "prev_invalid_sql",
-                "prev_error_msg",
-                "question_0",
-                "query_0",
-                "question_1",
-                "query_1",
-                "cot_instructions",
-            ]
-        ].apply(
+        df["prompt"] = df.apply(
             lambda row: generate_prompt(
                 prompt_file,
                 row["question"],
@@ -97,6 +80,7 @@ def run_vllm_eval(args):
                 row["question_1"],
                 row["query_1"],
                 row["cot_instructions"],
+                row["cot_pregen"],
                 public_data,
                 args.num_columns,
                 args.shuffle_metadata,

--- a/main.py
+++ b/main.py
@@ -24,7 +24,7 @@ if __name__ == "__main__":
     parser.add_argument("-c", "--num_columns", type=int, default=20)
     parser.add_argument("-s", "--shuffle_metadata", action="store_true")
     parser.add_argument("-k", "--k_shot", action="store_true")
-    parser.add_argument("--cot_table_alias", action="store_true")
+    parser.add_argument("--cot_table_alias", type=str)
     # execution-related parameters
     parser.add_argument("-o", "--output_file", nargs="+", type=str, required=True)
     parser.add_argument("-p", "--parallel_threads", type=int, default=5)

--- a/prompts/prompt_cot.md
+++ b/prompts/prompt_cot.md
@@ -1,9 +1,9 @@
 <|start_header_id|>user<|end_header_id|>
 
 Generate a SQL query to answer this question: `{user_question}`
-{instructions}{glossary}
+{instructions}
 DDL statements:
-{table_metadata_string}
+{table_metadata_string}<|eot_id|><|start_header_id|>assistant<|end_header_id|>
 
-{cot_instructions}Generate a valid SQL query that answers the question `{user_question}`, and only references the tables and columns in the DDL statements.<|eot_id|><|start_header_id|>assistant<|end_header_id|>
-
+The following SQL query best answers the question `{user_question}`
+```sql

--- a/prompts/prompt_cot.md
+++ b/prompts/prompt_cot.md
@@ -3,7 +3,7 @@
 Generate a SQL query to answer this question: `{user_question}`
 {instructions}
 DDL statements:
-{table_metadata_string}<|eot_id|><|start_header_id|>assistant<|end_header_id|>
+{table_metadata_string}
 
-The following SQL query best answers the question `{user_question}`
-```sql
+Generate a valid SQL query that answers the question `{user_question}`, and only references the tables and columns in the DDL statements.<|eot_id|><|start_header_id|>assistant<|end_header_id|>
+

--- a/prompts/prompt_cot.md
+++ b/prompts/prompt_cot.md
@@ -5,5 +5,5 @@ Generate a SQL query to answer this question: `{user_question}`
 DDL statements:
 {table_metadata_string}
 
-Generate a valid SQL query that answers the question `{user_question}`, and only references the tables and columns in the DDL statements.<|eot_id|><|start_header_id|>assistant<|end_header_id|>
+{cot_instructions}Generate a valid SQL query that answers the question `{user_question}`, and only references the tables and columns in the DDL statements.<|eot_id|><|start_header_id|>assistant<|end_header_id|>
 

--- a/utils/gen_prompt.py
+++ b/utils/gen_prompt.py
@@ -60,16 +60,17 @@ def generate_aliases(table_names: list) -> str:
     Generate aliases for table names
     """
     aliases = {}
+    reserved_keywords = ['all', 'and', 'any', 'as', 'asc', 'do', 'end', 'for', 'in', 'is', 'not', 'to']
     for table_name in table_names:
         alias = table_name[0]
-        if alias in aliases.values() and "_" in table_name:
+        if (alias in aliases.values() and "_" in table_name) or alias.lower() in reserved_keywords:
             alias = table_name.split("_")[0] + table_name.split("_")[1]
-        if alias in aliases.values():
+        if alias in aliases.values() or alias.lower() in reserved_keywords:
             alias = table_name[:2]
-        if alias in aliases.values():
+        if alias in aliases.values() or alias.lower() in reserved_keywords:
             alias = table_name[:3]
         num = 2
-        while alias in aliases.values():
+        while (alias in aliases.values() or alias.lower() in reserved_keywords):
             alias = table_name[0] + str(num)
             num += 1
 

--- a/utils/gen_prompt.py
+++ b/utils/gen_prompt.py
@@ -55,31 +55,48 @@ def to_prompt_schema(
         md_create += ");\n"
     return md_create
 
+
 def generate_aliases(table_names: list) -> str:
     """
     Generate aliases for table names
     """
     aliases = {}
-    reserved_keywords = ['all', 'and', 'any', 'as', 'asc', 'do', 'end', 'for', 'in', 'is', 'not', 'to']
+    reserved_keywords = [
+        "all",
+        "and",
+        "any",
+        "as",
+        "asc",
+        "do",
+        "end",
+        "for",
+        "in",
+        "is",
+        "not",
+        "to",
+    ]
     for table_name in table_names:
         alias = table_name[0]
-        if (alias in aliases.values() and "_" in table_name) or alias.lower() in reserved_keywords:
+        if (
+            alias in aliases.values() and "_" in table_name
+        ) or alias.lower() in reserved_keywords:
             alias = table_name.split("_")[0] + table_name.split("_")[1]
         if alias in aliases.values() or alias.lower() in reserved_keywords:
             alias = table_name[:2]
         if alias in aliases.values() or alias.lower() in reserved_keywords:
             alias = table_name[:3]
         num = 2
-        while (alias in aliases.values() or alias.lower() in reserved_keywords):
+        while alias in aliases.values() or alias.lower() in reserved_keywords:
             alias = table_name[0] + str(num)
             num += 1
 
         aliases[table_name] = alias
-    
+
     aliases_str = ""
     for table_name, alias in aliases.items():
         aliases_str += f"-- {table_name} AS {alias}, "
     return aliases
+
 
 def generate_prompt(
     prompt_file,

--- a/utils/gen_prompt.py
+++ b/utils/gen_prompt.py
@@ -80,7 +80,7 @@ def generate_aliases(table_names: list) -> str:
         if (
             alias in aliases.values() and "_" in table_name
         ) or alias.lower() in reserved_keywords:
-            alias = table_name.split("_")[0] + table_name.split("_")[1]
+            alias = table_name.split("_")[0][0] + table_name.split("_")[1][0]
         if alias in aliases.values() or alias.lower() in reserved_keywords:
             alias = table_name[:2]
         if alias in aliases.values() or alias.lower() in reserved_keywords:

--- a/utils/gen_prompt.py
+++ b/utils/gen_prompt.py
@@ -76,6 +76,8 @@ def generate_aliases(table_names: list) -> str:
         "to",
     ]
     for table_name in table_names:
+        if "." in table_name:
+            table_name = table_name.split(".", 1)[1]
         alias = table_name[0]
         if (
             alias in aliases.values() and "_" in table_name

--- a/utils/gen_prompt.py
+++ b/utils/gen_prompt.py
@@ -94,8 +94,8 @@ def generate_aliases(table_names: list) -> str:
 
     aliases_str = ""
     for table_name, alias in aliases.items():
-        aliases_str += f"-- {table_name} AS {alias}, "
-    return aliases
+        aliases_str += f"-- {table_name} AS {alias}\n"
+    return aliases_str
 
 
 def generate_prompt(
@@ -221,7 +221,7 @@ def generate_prompt(
         cot_instructions="",
     )
 
-    if "cot_instructions" in prompt:
+    if "cot_instructions":
         table_aliases = generate_aliases(table_names)
         prompt = prompt + table_aliases
     return prompt

--- a/utils/gen_prompt.py
+++ b/utils/gen_prompt.py
@@ -116,6 +116,7 @@ def generate_prompt(
     question_1="",
     query_1="",
     cot_instructions="",
+    cot_pregen=False,
     public_data=True,
     columns_to_keep=40,
     shuffle_metadata=False,
@@ -220,10 +221,10 @@ def generate_prompt(
         query_0=query_0,
         question_1=question_1,
         query_1=query_1,
-        cot_instructions="",
+        cot_instructions=cot_instructions,
     )
 
-    if "cot_instructions":
+    if cot_pregen:
         table_aliases = generate_aliases(table_names)
         prompt = prompt + table_aliases
     return prompt

--- a/utils/questions.py
+++ b/utils/questions.py
@@ -120,7 +120,7 @@ def prepare_questions_df(
         )
     else:
         question_query_df["cot_instructions"] = ""
-    
+
     if cot_table_alias == "pregen":
         question_query_df["cot_pregen"] = True
     else:

--- a/utils/questions.py
+++ b/utils/questions.py
@@ -114,11 +114,16 @@ def prepare_questions_df(
         question_query_df["query_1"] = ""
 
     # add all cot instructions to the `cot_instructions` column
-    if cot_table_alias:
+    if cot_table_alias == "instruct":
         question_query_df["cot_instructions"] = (
             "List the table aliases for each table as comments, starting with the most relevant tables to the question."
         )
     else:
         question_query_df["cot_instructions"] = ""
+    
+    if cot_table_alias == "pregen":
+        question_query_df["cot_pregen"] = True
+    else:
+        question_query_df["cot_pregen"] = False
 
     return question_query_df


### PR DESCRIPTION
This automatically generates relevant table aliases and appends it to a prompt. Doing so transfers the onus of creating table aliases away from the LLM. We _may_ have to retrain our LLM to expect this kind of prompting, so that it expects a more varied source of inputs.

Here's an example of how to run this.
```bash
python main.py \
-db postgres \
-q "data/questions_gen_postgres.csv" "data/instruct_basic_postgres.csv" "data/instruct_advanced_postgres.csv" "data/idk.csv" \
-o results/classic_new_reprompt.csv results/basic_new_reprompt.csv results/advanced_new_reprompt.csv results/idk_new_reprompt.csv \
-g api \
-b 1 \
-f prompts/prompt_cot.md \
--api_url "YOUR_API_ENDPOINT" \
--api_type "vllm" \
-p 10 \
-c 0 --logprobs --cot_table_alias
```