### PR TITLE
Fix pruning and the logic of md retrieval

### DIFF
--- a/utils/gen_prompt.py
+++ b/utils/gen_prompt.py
@@ -158,7 +158,7 @@ def generate_prompt(
             table_metadata_string = to_prompt_schema(md, shuffle_metadata)
         else:
             raise ValueError("columns_to_keep must be >= 0")
-        
+
         # get join list if retrieving full metadata
         join_list = []
         for values in column_join.values():
@@ -169,9 +169,7 @@ def generate_prompt(
                 join_list.append(join_str)
 
         if len(join_list) > 0:
-            join_list = "\nHere is a list of joinable columns:\n" + "\n".join(
-                join_list
-            )
+            join_list = "\nHere is a list of joinable columns:\n" + "\n".join(join_list)
         else:
             join_list = ""
 

--- a/utils/pruning.py
+++ b/utils/pruning.py
@@ -113,8 +113,22 @@ def get_md_emb(
     topk_table_columns = {}
     table_column_names = set()
     for score, index in zip(top_k_scores, top_k_indices):
-        table_name, column_info = column_info_csv[index].split(".", 1)
-        column_tuple = tuple(column_info.split(",", 2))
+        table_col_name, column_info = column_info_csv[index].split(",", 1)
+        # if count of "." is more than 1, then split into schema, table, column
+        if table_col_name.count(".") > 1:
+            schema, table_name, column_name = table_col_name.split(".", 2)
+            table_name = f"{schema}.{table_name}"
+        else:
+            table_name, column_name = table_col_name.split(".", 1)
+        # check if column_info has numeric or decimal in it
+        if "numeric" in column_info.lower() or "decimal" in column_info.lower():
+            column_type, col_desc = column_info.split("),", 1)
+            column_type += ")"
+        else:
+            column_type, col_desc = tuple(column_info.split(",", 1))
+        column_tuple = (column_name, column_type, col_desc)
+        column_tuple = tuple(filter(None, column_tuple))
+
         if table_name not in topk_table_columns:
             topk_table_columns[table_name] = []
         topk_table_columns[table_name].append(column_tuple)


### PR DESCRIPTION
- Edited logic of metadata retrieval, such that translation still takes place even if columns_to_keep > 0 (simply shifted the if/else logic)
- Also fixed pruning code such that it still works with translation. Previously it had issues splitting data types with commas e.g. `numeric(10,5)` as well as tables that included schema names e.g. `consumer_div.wallet_transactions_daily`. These issues led to the incorrect retrieval of metadata, resulting in error execs in sql-eval.