### PR TITLE
Add prealias option

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,7 +371,7 @@ You can use the following flags in the command line to change the configurations
 | -c, --num_columns        | Number of columns, default 20. To not prune the columns, set it to 0. |
 | -s, --shuffle_metadata   | Shuffle metadata, default False. This shuffles the order of the tables within the schema and the order of the columns within each table but does not shift columns between tables (to preserve the structure of the database). |
 | -k, --k_shot             | Used when you want to include k-shot examples in your prompt. Make sure that the column 'k_shot_prompt' exists in your questions_file.                                                                                                    |
-| --cot_table_alias        | Used when you want to include chain-of-thought instructions before the actual sql generation. Allowed values are `instruct` and `pregen`. If using `instruct`, make sure that the placeholder '{cot_instructions}' exists in your prompt file. |                                                                                                    |
+| --cot_table_alias        | Used when you want to include chain-of-thought instructions before the actual sql generation. Allowed values are `instruct`, `prealias` and `pregen`. If using `instruct` or `prealias`, make sure that the placeholder '{cot_instructions}' exists in your prompt file. `instruct` will get your model generate the chain-of-thought table aliases, while `prealias` would already generate the aliases in the prompt. |                                                                                                    |
 
 ### Execution-related parameters
 

--- a/run_checkpoints.sh
+++ b/run_checkpoints.sh
@@ -1,6 +1,6 @@
 #!/bin/zsh
 
-model_names=("sqlcoder_8b_fullft_ds_003_llama3_mgn1_b1_0900_b2_0990")
+model_names=("sqlcoder_8b_fullft_ds_011_llama3_mgn1_b1_0900_b2_0990")
 PORT=8082 # avoid 8081 as it's used by nginx
 export CUDA_VISIBLE_DEVICES=0 # set gpu you want to use (just 1 will do)
 

--- a/run_checkpoints_cot.sh
+++ b/run_checkpoints_cot.sh
@@ -1,6 +1,6 @@
 #!/bin/zsh
 
-model_names=("sqlcoder_8b_fullft_ds_003_llama3_mgn1_b1_0900_b2_0990")
+model_names=("sqlcoder_8b_fullft_ds_011_llama3_mgn1_b1_0900_b2_0990")
 PORT=8083 # avoid 8081 as it's used by nginx
 export CUDA_VISIBLE_DEVICES=1 # set gpu you want to use (just 1 will do)
 
@@ -46,7 +46,7 @@ for model_name in "${model_names[@]}"; do
       --api_url "http://localhost:${PORT}/generate" \
       --api_type "vllm" \
       -p 10 \
-      --cot_table_alias
+      --cot_table_alias "prealias"
     # finally, kill the api server
     pkill -9 -f "python3 utils/api_server.py.*--port ${PORT}"
   done


### PR DESCRIPTION
Add `prealias` option to `--cot_table_alias`. The difference from the existing `instruct` option is that `instruct` will get the model to generate the chain-of-thought table aliases, while `prealias` would already generate the aliases in the prompt.