### PR TITLE
VLLM version support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ results_fn_postgres/*.json
 
 # all eda notebooks
 eda_*.ipynb
+
+# wandb output (created when running upload_wandb.ipynb)
+wandb/


### PR DESCRIPTION
Updated api server to pass in the prompt token ids in the right format depending on the vllm version.
Tested with version [0.5.0.post1](https://github.com/vllm-project/vllm/releases/tag/v0.5.0.post1), which I upgraded locally in my runpod instance and it works (with the usual `run_checkpoints_cot.sh` script).