### PR TITLE
Fix translation script

### DIFF
--- a/prompts/prompt_cot.md
+++ b/prompts/prompt_cot.md
@@ -1,9 +1,9 @@
 <|start_header_id|>user<|end_header_id|>
 
-Generate a SQL query to answer this question: `{user_question}`
+Generate a {db_type} query to answer this question: `{user_question}`
 {instructions}
 DDL statements:
 {table_metadata_string}
 
-{cot_instructions}Generate a valid SQL query that answers the question `{user_question}`, and only references the tables and columns in the DDL statements.<|eot_id|><|start_header_id|>assistant<|end_header_id|>
+{cot_instructions}Generate a valid {db_type} query that answers the question `{user_question}`, and only references the tables and columns in the DDL statements.<|eot_id|><|start_header_id|>assistant<|end_header_id|>
 

--- a/run_checkpoints_adapters.sh
+++ b/run_checkpoints_adapters.sh
@@ -9,7 +9,7 @@ preprocess_adapters=true # set to false if you have already preprocessed the ada
 cot_table_alias=true # set to true if you want to use the cot_table_alias prompt in evals
 
 # check that the base model was trained on cot data otherwise print a warning
-if [[ ! $base_model_path == *"cot"* ]]; then
+if [[ ! $base_model_path == *"cot"* ]] && [[ $cot_table_alias == true ]]; then
   echo "WARNING: Base model was not trained on 'cot' data. This may lead to less than optimal results"
 fi
 for model_name in "${model_names[@]}"; do

--- a/translate_sql_dialect.py
+++ b/translate_sql_dialect.py
@@ -32,7 +32,7 @@ bigquery_proj = os.getenv(
     "BIGQUERY_PROJ"
 )  # Set this to your BigQuery project ID, leave empty if dialect is not BigQuery
 
-model = "gpt-4o"  # Model to use for translation of invalid SQL
+model = "gpt-4-turbo"  # Model to use for translation of invalid SQL
 max_concurrent = 5  # Maximum number of concurrent coroutines when querying openai
 if "postgres" in dataset_file:
     output_file = dataset_file.replace("postgres", dialect)

--- a/utils/dialects.py
+++ b/utils/dialects.py
@@ -216,7 +216,6 @@ def ddl_to_dialect(ddl, db_type, dialect):
         print("Error transpiling ddl", e)
         print(ddl)
         raise
-    translated = [stmt + ";" for stmt in translated]
     translated = "\n".join(translated)
     return translated
 

--- a/utils/dialects.py
+++ b/utils/dialects.py
@@ -207,30 +207,16 @@ def ddl_to_dialect(ddl, db_type, dialect):
     """
     Preprocesses the ddl and then translates it to another dialect with sqlglot.
     """
-    # remove lines that start with PRIMARY or FOREIGN or UNIQUE
-    lines = [
-        line
-        for line in ddl
-        if not any(
-            line.strip().startswith(keyword)
-            for keyword in ["PRIMARY", "FOREIGN", "UNIQUE", "CONSTRAINT", "--"]
-        )
-    ]
-    # join the list as a str
-    ddl = "".join(lines)
-    ddl = ddl.replace("public.", "")
+
     ddl = ddl.replace("UNIQUE", "")
-    ddl = ddl.replace("VALUES", "VALUES\n")
-    ddl = ddl.replace("),", "),\n")
-    ddl = ddl.replace(")\n\nCREATE", ");\n\nCREATE")
-    ddl = ddl.replace(")\n\nINSERT", ");\n\nINSERT")
     ddl = ddl.replace(" PRIMARY KEY", "")
     try:
-        translated = sqlglot.transpile(ddl, read=db_type, write=dialect)
+        translated = sqlglot.transpile(ddl, read=db_type, write=dialect, pretty=True)
     except Exception as e:
         print("Error transpiling ddl", e)
         print(ddl)
         raise
+    translated = [stmt + ";" for stmt in translated]
     translated = "\n".join(translated)
     return translated
 

--- a/utils/gen_prompt.py
+++ b/utils/gen_prompt.py
@@ -185,7 +185,7 @@ def generate_prompt(
         if db_type in ["sqlite", "mysql", "bigquery"]:
             for schema_name in schema_names:
                 cot_instructions = cot_instructions.replace(f"{schema_name}.", "")
-        
+
         # transform metadata string to target dialect if necessary
         if db_type in ["postgres", "snowflake"]:
             table_metadata_string = table_metadata_ddl + join_str

--- a/utils/gen_prompt.py
+++ b/utils/gen_prompt.py
@@ -181,6 +181,11 @@ def generate_prompt(
                 table_metadata_ddl = (
                     f"CREATE SCHEMA IF NOT EXISTS {schema_name};\n" + table_metadata_ddl
                 )
+        # remove schema names from cot_instructions if db_type is in ["sqlite", "mysql", "bigquery"]
+        if db_type in ["sqlite", "mysql", "bigquery"]:
+            for schema_name in schema_names:
+                cot_instructions = cot_instructions.replace(f"{schema_name}.", "")
+        
         # transform metadata string to target dialect if necessary
         if db_type in ["postgres", "snowflake"]:
             table_metadata_string = table_metadata_ddl + join_str


### PR DESCRIPTION
- Previously, schema names could still be found in the instructions of sqlite, mysql, bigquery. Script will now scrub these.
- Fixed `ddl_to_dialect` which had redundant preprocessing that was accidentally removing some column descriptions. 
- Preserved new lines in translated ddl with the arg `pretty=True`
- Removed schema names from cot_instructions if one of the 3 dialects above.
- Also changed model for translation to gpt-4-turbo. Hopefully it can correct the date arithmetic translations in #172
- Minor: took the chance to modify a print statement in run_checkpoints_adapters
