### PR TITLE
Pop sql_lora_name

### DIFF
--- a/utils/api_server.py
+++ b/utils/api_server.py
@@ -53,6 +53,7 @@ async def generate(request: Request) -> Response:
     prompt = request_dict.pop("prompt")
     stream = request_dict.pop("stream", False)
     sql_lora_path = request_dict.pop("sql_lora_path", None)
+    request_dict.pop("sql_lora_name", None)
     lora_request = (
         LoRARequest("sql_adapter", 1, sql_lora_path) if sql_lora_path else None
     )


### PR DESCRIPTION
- Pop sql_lora_name param which is not used in the api_server within sql-eval. The param is only used when making requests to the production server.