### PR TITLE
Together.ai Runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,21 @@ python -W ignore main.py \
   -n 10
 ```
 
+### Bedrock
+
+```bash
+python3 main.py \
+  -db postgres \
+  -q data/instruct_basic_postgres.csv data/instruct_advanced_postgres.csv data/questions_gen_postgres.csv \
+  -o results/bedrock_llama_70b_basic.csv results/bedrock_llama_70b_advanced.csv results/bedrock_llama_70b_v1.csv \
+  -g bedrock \
+  -f prompts/prompt_cot_postgres.md \
+  --cot_table_alias prealias \
+  -m meta.llama3-70b-instruct-v1:0 \
+  -c 0 \
+  -p 10
+```
+
 ### Together
 
 Before running this, you must create an account with [Together.ai](https://together.ai/) and obtain an API key and store it with `export TOGETHER_API_KEY=<your_api_key>`. Then, install `together` with `pip install together`. You can then run the following command:

--- a/README.md
+++ b/README.md
@@ -379,6 +379,23 @@ python -W ignore main.py \
   -n 10
 ```
 
+### Together
+
+Before running this, you must create an account with [Together.ai](https://together.ai/) and obtain an API key and store it with `export TOGETHER_API_KEY=<your_api_key>`. Then, install `together` with `pip install together`. You can then run the following command:
+
+```bash
+python3 main.py \
+  -db postgres \
+  -q data/instruct_basic_postgres.csv data/instruct_advanced_postgres.csv data/questions_gen_postgres.csv \
+  -o results/together_llama_70b_basic.csv results/together_llama_70b_advanced.csv results/together_llama_70b_v1.csv \
+  -g together \
+  -f prompts/prompt_together.json \
+  --cot_table_alias prealias \
+  -m "meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo" \
+  -c 0 \
+  -p 10
+```
+
 ## CLI Flags
 
 You can use the following flags in the command line to change the configurations of your evaluation runs.
@@ -397,7 +414,7 @@ You can use the following flags in the command line to change the configurations
 
 | CLI Flags        | Description                                                                                                                                                                                                                                                                                                                                                                                       |
 | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| -g, --model_type | Model type used. Make sure this matches the model used. Currently defined options in `main.py` are `oa` for OpenAI models, `anthropic` for Anthropic models, `hf` for Hugging Face models, `vllm` for a vllm runner, `api` for API endpoints, `llama_cpp` for llama cpp, and `mlx` for mlx                                                                                                        |
+| -g, --model_type | Model type used. Make sure this matches the model used. Currently defined options in `main.py` are `oa` for OpenAI models, `anthropic` for Anthropic models, `hf` for Hugging Face models, `vllm` for a vllm runner, `api` for API endpoints, `llama_cpp` for llama cpp, `mlx` for mlx, `bedrock` for AWS bedrock API, `together` for together.ai's API           |
 | -m, --model      | Model that will be tested and used to generate the queries. Some options for OpenAI models are chat models `gpt-3.5-turbo-0613` and `gpt-4-0613`. Options for Anthropic include the latest claude-3 family of models (e.g. `claude-3-opus-20240229`). For Hugging Face, and VLLM models, simply use the path of your chosen model (e.g. `defog/sqlcoder`). |
 | -a, --adapter    | Path to the relevant adapter model you're using. Only available for the `hf_runner`.                                                                                                                                                                                                                                                                                                              |
 | --api_url        | The URL of the custom API you want to send the prompt to. Only used when model_type is `api`.                                                                                                                                                                                                                                                                                                     |

--- a/eval/together_runner.py
+++ b/eval/together_runner.py
@@ -1,0 +1,175 @@
+import os
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import Dict
+
+from eval.eval import compare_query_results
+import pandas as pd
+from utils.gen_prompt import generate_prompt
+from utils.questions import prepare_questions_df
+from utils.creds import db_creds_all
+from tqdm import tqdm
+from time import time
+from together import Together
+from utils.reporting import upload_results
+
+
+client = Together(api_key=os.environ.get('TOGETHER_API_KEY'))
+
+
+def process_row(row: Dict, model: str):
+    start_time = time()
+    if model.startswith("meta-llama"):
+        stop = ["<|eot_id|>","<|eom_id|>"]
+    else:
+        print("Undefined stop token(s). Please specify the stop token(s) for the model.")
+        stop = []
+    messages = row["prompt"]
+    response = client.chat.completions.create(
+        model=model,
+        messages=messages,
+        max_tokens=800,
+        temperature=0.0,
+        stop=stop,
+        stream=False
+    )
+    content = response.choices[0].message.content
+    generated_query = content.split("```", 1)[0].strip()
+    end_time = time()
+
+
+    row["generated_query"] = generated_query
+    row["latency_seconds"] = end_time - start_time
+    row["tokens_used"] = None
+    golden_query = row["query"]
+    db_name = row["db_name"]
+    db_type = row["db_type"]
+    question = row["question"]
+    query_category = row["query_category"]
+    table_metadata_string = row["table_metadata_string"]
+    exact_match = correct = 0
+
+    try:
+        exact_match, correct = compare_query_results(
+            query_gold=golden_query,
+            query_gen=generated_query,
+            db_name=db_name,
+            db_type=db_type,
+            db_creds=db_creds_all[row["db_type"]],
+            question=question,
+            query_category=query_category,
+            table_metadata_string=table_metadata_string,
+        )
+        row["exact_match"] = int(exact_match)
+        row["correct"] = int(correct)
+        row["error_msg"] = ""
+    except Exception as e:
+        row["error_db_exec"] = 1
+        row["error_msg"] = f"QUERY EXECUTION ERROR: {e}"
+
+    return row
+
+
+def run_together_eval(args):
+    # get params from args
+    questions_file_list = args.questions_file
+    prompt_file_list = args.prompt_file
+    num_questions = args.num_questions
+    public_data = not args.use_private_data
+    output_file_list = args.output_file
+    k_shot = args.k_shot
+    max_workers = args.parallel_threads
+    db_type = args.db_type
+    decimal_points = args.decimal_points
+    model = args.model
+    cot_table_alias = args.cot_table_alias
+
+    for questions_file, prompt_file, output_file in zip(
+        questions_file_list, prompt_file_list, output_file_list
+    ):
+        if not prompt_file.endswith(".json"):
+            raise ValueError(f"Prompt file must be a JSON file. Got {prompt_file}")
+        print(f"Using prompt file {prompt_file}")
+        # get questions
+        print("Preparing questions...")
+        print(
+            f"Using {'all' if num_questions is None else num_questions} question(s) from {questions_file}"
+        )
+        df = prepare_questions_df(
+            questions_file, db_type, num_questions, k_shot, cot_table_alias
+        )
+        # create a prompt for each question
+        # note that the prompt for together ai uses the openai chat API
+        df["prompt"] = df.apply(
+            lambda row: generate_prompt(
+                prompt_file,
+                row["question"],
+                row["db_name"],
+                row["db_type"],
+                row["instructions"],
+                row["k_shot_prompt"],
+                row["glossary"],
+                row["table_metadata_string"],
+                row["prev_invalid_sql"],
+                row["prev_error_msg"],
+                row["question_0"],
+                row["query_0"],
+                row["question_1"],
+                row["query_1"],
+                row["cot_instructions"],
+                row["cot_pregen"],
+                public_data,
+                args.num_columns,
+                args.shuffle_metadata,
+                row["table_aliases"],
+            ),
+            axis=1,
+        )
+
+        total_tried = 0
+        total_correct = 0
+        output_rows = []
+
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            futures = []
+            for row in df.to_dict("records"):
+                futures.append(
+                    executor.submit(process_row, row, model)
+                )
+
+            with tqdm(as_completed(futures), total=len(futures)) as pbar:
+                for f in pbar:
+                    row = f.result()
+                    output_rows.append(row)
+                    if row["correct"]:
+                        total_correct += 1
+                    total_tried += 1
+                    pbar.update(1)
+                    pbar.set_description(
+                        f"Correct so far: {total_correct}/{total_tried} ({100*total_correct/total_tried:.2f}%)"
+                    )
+
+        output_df = pd.DataFrame(output_rows)
+        del output_df["prompt"]
+        print(output_df.groupby("query_category")[["correct", "error_db_exec"]].mean())
+        output_df = output_df.sort_values(by=["db_name", "query_category", "question"])
+        # get directory of output_file and create if not exist
+        output_dir = os.path.dirname(output_file)
+        if not os.path.exists(output_dir):
+            os.makedirs(output_dir)
+        try:
+            output_df.to_csv(output_file, index=False, float_format="%.2f")
+        except:
+            output_df.to_pickle(output_file)
+
+        results = output_df.to_dict("records")
+        # upload results
+        with open(prompt_file, "r") as f:
+            prompt = f.read()
+        if args.upload_url is not None:
+            upload_results(
+                results=results,
+                url=args.upload_url,
+                runner_type="api_runner",
+                prompt=prompt,
+                args=args,
+            )

--- a/eval/together_runner.py
+++ b/eval/together_runner.py
@@ -13,15 +13,17 @@ from together import Together
 from utils.reporting import upload_results
 
 
-client = Together(api_key=os.environ.get('TOGETHER_API_KEY'))
+client = Together(api_key=os.environ.get("TOGETHER_API_KEY"))
 
 
 def process_row(row: Dict, model: str):
     start_time = time()
     if model.startswith("meta-llama"):
-        stop = ["<|eot_id|>","<|eom_id|>"]
+        stop = ["<|eot_id|>", "<|eom_id|>"]
     else:
-        print("Undefined stop token(s). Please specify the stop token(s) for the model.")
+        print(
+            "Undefined stop token(s). Please specify the stop token(s) for the model."
+        )
         stop = []
     messages = row["prompt"]
     response = client.chat.completions.create(
@@ -30,12 +32,11 @@ def process_row(row: Dict, model: str):
         max_tokens=800,
         temperature=0.0,
         stop=stop,
-        stream=False
+        stream=False,
     )
     content = response.choices[0].message.content
     generated_query = content.split("```", 1)[0].strip()
     end_time = time()
-
 
     row["generated_query"] = generated_query
     row["latency_seconds"] = end_time - start_time
@@ -132,9 +133,7 @@ def run_together_eval(args):
         with ThreadPoolExecutor(max_workers=max_workers) as executor:
             futures = []
             for row in df.to_dict("records"):
-                futures.append(
-                    executor.submit(process_row, row, model)
-                )
+                futures.append(executor.submit(process_row, row, model))
 
             with tqdm(as_completed(futures), total=len(futures)) as pbar:
                 for f in pbar:

--- a/main.py
+++ b/main.py
@@ -131,6 +131,10 @@ if __name__ == "__main__":
         from eval.bedrock_runner import run_bedrock_eval
 
         run_bedrock_eval(args)
+    elif args.model_type == "together":
+        from eval.together_runner import run_together_eval
+
+        run_together_eval(args)
     else:
         raise ValueError(
             f"Invalid model type: {args.model_type}. Model type must be one of: 'oa', 'hf', 'anthropic', 'vllm', 'api', 'llama_cpp', 'mlx', 'gemini', 'mistral'"

--- a/prompts/prompt_together.json
+++ b/prompts/prompt_together.json
@@ -1,0 +1,14 @@
+[
+  {
+    "role": "system",
+    "content": "Your role is to convert a user question to a {db_type} query, given a database schema."
+  },
+  {
+    "role": "user",
+    "content": "Generate a SQL query that answers the question `{user_question}`.\n{instructions}\nThis query will run on a database whose schema is represented in this SQL DDL:\n{table_metadata_string}\n{table_aliases}\n{pruned_join_str}\n{k_shot_prompt}\nReturn the SQL query that answers the question `{user_question}`"
+  },
+  {
+    "role": "assistant",
+    "content": "```sql\n"
+  }
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ snowflake-connector-python
 spacy
 sqlalchemy
 tiktoken
+together
 torch
 tqdm
 transformers

--- a/utils/gen_prompt.py
+++ b/utils/gen_prompt.py
@@ -131,6 +131,7 @@ def generate_prompt(
     Else, we will treat the file as a string template.
     """
     from defog_data.metadata import dbs  # to avoid CI error
+
     is_json = prompt_file.endswith(".json")
     if is_json:
         with open(prompt_file, "r") as f:

--- a/utils/questions.py
+++ b/utils/questions.py
@@ -136,8 +136,12 @@ def prepare_questions_df(
         question_query_df["cot_instructions"] = question_query_df["db_name"].apply(
             get_table_aliases
         )
+        question_query_df["table_aliases"] = question_query_df["db_name"].apply(
+            get_table_aliases
+        )
     else:
         question_query_df["cot_instructions"] = ""
+        question_query_df["table_aliases"] = ""
 
     if cot_table_alias == "pregen":
         question_query_df["cot_pregen"] = True


### PR DESCRIPTION
# Changes
- Add runner for together.ai's API. Quite similar to `bedrock_runner.py`
- Extended `generate_prompt.py` to take in json files, where we have a list of messages with `role` and `content`. This returns a list of messages (dict) for the `messages` parameter in the [openai create chat completions api](https://platform.openai.com/docs/api-reference/chat/create).
- Add table aliases as a different field `table_aliases` in the main dataframe, as `cot_instructions` is a more general and experimental field (e.g. for reasoning etc). We get `prompt_together.json` to read off the `table_aliases` field instead of using `cot_instructions`.

# Testing
Ran the full evaluation over `meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo` as follows:
```sh
python3 main.py \
  -db postgres \
  -q data/instruct_basic_postgres.csv data/instruct_advanced_postgres.csv data/questions_gen_postgres.csv \
  -o results/together_llama_70b_basic.csv results/together_llama_70b_advanced.csv results/together_llama_70b_v1.csv \
  -g together \
  -f prompts/prompt_together.json \
  --cot_table_alias prealias \
  -m "meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo" \
  -c 0 \
  -p 10
```
Got the following results:
| Question File                     | Accuracy |
|----------------------------------|----------|
| instruct_basic_postgres.csv       | 90.00%   |
| instruct_advanced_postgres.csv    | 67.19%   |
| questions_gen_postgres.csv        | 80.00%   |

The results are slightly better than the previous evaluation on bedrock, see https://github.com/defog-ai/sql-eval/pull/116.

Sppedwise it was extremely fast (at 10 concurrent requests):
- median latency on v1 ws 0.99s
- p99 latency on v1 was 2.43s

```
Using prompt file prompts/prompt_together.json
Preparing questions...
Using all question(s) from data/instruct_basic_postgres.csv
Correct so far: 36/40 (90.00%): 100%|████████████████████████████████████████████████████████████| 40/40 [00:04<00:00,  8.09it/s]
                                   correct  error_db_exec
query_category                                           
basic_group_order_limit              1.000            0.0
basic_join_date_group_order_limit    0.750            0.0
basic_join_distinct                  0.875            0.0
basic_join_group_order_limit         0.875            0.0
basic_left_join                      1.000            0.0
Using prompt file prompts/prompt_together.json
Preparing questions...
Using all question(s) from data/instruct_advanced_postgres.csv
Correct so far: 14/18 (77.78%):  39%|███████████████████████▍                                    | 25/64 [00:05<00:06,  6.03it/s]/home/ubuntu/sql-eval/eval/eval.py:584: FutureWarning: Downcasting object dtype arrays on .fillna, .ffill, .bfill is deprecated and will change in a future version. Call result.infer_objects(copy=False) instead. To opt-in to the future behavior, set `pd.set_option('future.no_silent_downcasting', True)`
  df_gen.fillna(-99999, inplace=True)
/home/ubuntu/sql-eval/eval/eval.py:585: FutureWarning: Downcasting object dtype arrays on .fillna, .ffill, .bfill is deprecated and will change in a future version. Call result.infer_objects(copy=False) instead. To opt-in to the future behavior, set `pd.set_option('future.no_silent_downcasting', True)`
  df_gold.fillna(-99999, inplace=True)
/home/ubuntu/sql-eval/eval/eval.py:584: FutureWarning: Downcasting object dtype arrays on .fillna, .ffill, .bfill is deprecated and will change in a future version. Call result.infer_objects(copy=False) instead. To opt-in to the future behavior, set `pd.set_option('future.no_silent_downcasting', True)`
  df_gen.fillna(-99999, inplace=True)
/home/ubuntu/sql-eval/eval/eval.py:585: FutureWarning: Downcasting object dtype arrays on .fillna, .ffill, .bfill is deprecated and will change in a future version. Call result.infer_objects(copy=False) instead. To opt-in to the future behavior, set `pd.set_option('future.no_silent_downcasting', True)`
  df_gold.fillna(-99999, inplace=True)
/home/ubuntu/sql-eval/eval/eval.py:584: FutureWarning: Downcasting object dtype arrays on .fillna, .ffill, .bfill is deprecated and will change in a future version. Call result.infer_objects(copy=False) instead. To opt-in to the future behavior, set `pd.set_option('future.no_silent_downcasting', True)`
  df_gen.fillna(-99999, inplace=True)
/home/ubuntu/sql-eval/eval/eval.py:585: FutureWarning: Downcasting object dtype arrays on .fillna, .ffill, .bfill is deprecated and will change in a future version. Call result.infer_objects(copy=False) instead. To opt-in to the future behavior, set `pd.set_option('future.no_silent_downcasting', True)`
  df_gold.fillna(-99999, inplace=True)
Correct so far: 43/64 (67.19%): 100%|████████████████████████████████████████████████████████████| 64/64 [00:14<00:00,  4.39it/s]
                              correct  error_db_exec
query_category                                      
instructions_cte_join           0.750          0.000
instructions_cte_window         0.500          0.000
instructions_date_join          0.500          0.125
instructions_string_matching    0.875          0.000
keywords_aggregate              0.875          0.000
keywords_ratio                  0.625          0.125
Using prompt file prompts/prompt_together.json
Preparing questions...
Using all question(s) from data/questions_gen_postgres.csv
Correct so far: 168/210 (80.00%): 100%|████████████████████████████████████████████████████████| 210/210 [00:23<00:00,  9.05it/s]
                 correct  error_db_exec
query_category                         
date_functions  0.600000       0.171429
group_by        0.914286       0.057143
instruct        0.857143       0.028571
order_by        0.828571       0.028571
ratio           0.828571       0.085714
table_join      0.771429       0.114286
```