### PR TITLE
Update openai runners

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,20 @@ python main.py \
   -c 0
 ```
 
+If testing with the latest `o1-*` models (which do not support system prompts), you should use a different prompt file, reduce parallel requests and increase the timeout:
+```bash
+python main.py \
+  -db postgres \
+  -q "data/questions_gen_postgres.csv" "data/instruct_basic_postgres.csv" "data/instruct_advanced_postgres.csv" \
+  -o results/openai_o1mini_classic.csv results/openai_o1mini_basic.csv results/openai_o1mini_advanced.csv \
+  -g oa \
+  -f prompts/prompt_openai_o1.json \
+  -m o1-mini \
+  -p 1 \
+  -t 120 \
+  -c 0
+```
+
 ### Anthropic
 
 To test out the full suite of questions for claude-3:

--- a/eval/openai_runner.py
+++ b/eval/openai_runner.py
@@ -65,7 +65,7 @@ def run_openai_eval(args):
                     table_metadata_string=row["table_metadata_string"],
                     prev_invalid_sql=row["prev_invalid_sql"],
                     prev_error_msg=row["prev_error_msg"],
-                    cot_instructions=row["cot_instructions"],
+                    table_aliases=row["table_aliases"],
                     columns_to_keep=args.num_columns,
                     shuffle=args.shuffle_metadata,
                 )

--- a/prompts/prompt_openai_o1.json
+++ b/prompts/prompt_openai_o1.json
@@ -1,0 +1,6 @@
+[
+  {
+    "role": "user",
+    "content": "Generate a SQL query for {db_type} that answers the question `{user_question}`.\n{instructions}\nThis query will run on a database whose schema is represented in this string:\n{table_metadata_string}\n{table_aliases}\n\nReturn only the SQL query, and nothing else."
+  }
+]

--- a/prompts/prompt_openai_o1.json
+++ b/prompts/prompt_openai_o1.json
@@ -1,6 +1,6 @@
 [
   {
     "role": "user",
-    "content": "Generate a SQL query for {db_type} that answers the question `{user_question}`.\n{instructions}\nThis query will run on a database whose schema is represented in this string:\n{table_metadata_string}\n{table_aliases}\n\nReturn only the SQL query, and nothing else."
+    "content": "Generate a SQL query for {db_type} that answers the question `{user_question}`.\n{instructions}\nThis query will run on a database whose schema is represented in this string:\n{table_metadata_string}\n\nReturn only the SQL query, and nothing else."
   }
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ sentence-transformers
 snowflake-connector-python
 spacy
 sqlalchemy
-tiktoken
+tiktoken==0.7.0
 together
 torch
 tqdm


### PR DESCRIPTION
Support evaluation of latest openai o1-* models. We branch out the code paths in the openai query generator by checking if the model is from the `o1-` family, as the o1 model doesn't support some parameters currently.

Tested o1-mini model:
```
$ python main.py \
  -db postgres \
  -q "data/questions_gen_postgres.csv" "data/instruct_basic_postgres.csv" "data/instruct_advanced_postgres.csv" \
  -o results/openai_o1mini_classic.csv results/openai_o1mini_basic.csv results/openai_o1mini_advanced.csv \
  -g oa \
  -f prompts/prompt_openai_o1.json \
  -m o1-mini \
  -p 1 \
  -t 120 \
  -c 0
```
(works, still running)

Previous gpt-4o request still works:
```
$ python main.py \
  -db postgres \
  -q "data/questions_gen_postgres.csv" "data/instruct_basic_postgres.csv" "data/instruct_advanced_postgres.csv" \
  -o results/openai_classic.csv results/openai_basic.csv results/openai_advanced.csv \
  -g oa \
  -f prompts/prompt_openai.json \
  -m gpt-4o \
  -p 10 \
  -c 0
/Users/jp/workspace/miniconda3/lib/python3.11/site-packages/bitsandbytes/cextension.py:34: UserWarning: The installed version of bitsandbytes was compiled without GPU support. 8-bit optimizers, 8-bit multiplication, and GPU quantization are unavailable.
  warn("The installed version of bitsandbytes was compiled without GPU support. "
'NoneType' object has no attribute 'cadam32bit_grad_fp32'
Using prompt file prompts/prompt_openai.json
Preparing questions...
Using all question(s) from data/questions_gen_postgres.csv
Correct so far: 186/210 (88.57%): 100%|███████████████████████████████████████████████████████████████████████████| 210/210 [00:25<00:00,  8.30it/s]
   query_category  num_rows  mean_correct  mean_error_db_exec
0  date_functions        35      0.771429            0.057143
1        group_by        35      0.971429            0.000000
2        instruct        35      0.914286            0.000000
3        order_by        35      0.914286            0.000000
4           ratio        35      0.771429            0.028571
5      table_join        35      0.971429            0.000000
Average correct rate: 0.89
Using prompt file prompts/prompt_openai.json
Preparing questions...
Using all question(s) from data/instruct_basic_postgres.csv
Correct so far: 39/40 (97.50%): 100%|███████████████████████████████████████████████████████████████████████████████| 40/40 [00:05<00:00,  7.39it/s]
                      query_category  num_rows  mean_correct  mean_error_db_exec
0            basic_group_order_limit         8         1.000                 0.0
1  basic_join_date_group_order_limit         8         1.000                 0.0
2                basic_join_distinct         8         1.000                 0.0
3       basic_join_group_order_limit         8         0.875                 0.0
4                    basic_left_join         8         1.000                 0.0
Average correct rate: 0.97
Using prompt file prompts/prompt_openai.json
Preparing questions...
Using all question(s) from data/instruct_advanced_postgres.csv
Correct so far: 55/64 (85.94%): 100%|███████████████████████████████████████████████████████████████████████████████| 64/64 [00:10<00:00,  5.83it/s]
                 query_category  num_rows  mean_correct  mean_error_db_exec
0         instructions_cte_join        16        0.9375               0.000
1       instructions_cte_window         8        0.7500               0.125
2        instructions_date_join        16        0.7500               0.000
3  instructions_string_matching         8        1.0000               0.000
4            keywords_aggregate         8        0.8750               0.000
5                keywords_ratio         8        0.8750               0.000
Average correct rate: 0.86
```