### PR TITLE
Added mysql case in cleaner

### DIFF
--- a/eval/api_runner.py
+++ b/eval/api_runner.py
@@ -148,7 +148,6 @@ def process_row(
     # clean up the generated query
     generated_query = clean_generated_query(generated_query)
 
-
     if "logprobs" in r.json():
         logprobs = r.json()["logprobs"]
 

--- a/eval/api_runner.py
+++ b/eval/api_runner.py
@@ -32,6 +32,12 @@ def clean_generated_query(query: str):
     # if the string ` / NULLIF (` is present, replace it with `/ NULLIF ( 1.0 * `.
     # This is a fix for ensuring that the denominator is always a float in division operations.
     query = query.replace("/ NULLIF (", "/ NULLIF (1.0 * ")
+
+    # remove extra spaces around brackets especially for MySQL
+    query = query.replace(" ( ", "(").replace(" )", ")")
+    query = query.replace(" (", "(").replace(") ", ")")
+    query = query.replace("( ", "(").replace(" )", ")")
+
     return query
 
 
@@ -142,8 +148,6 @@ def process_row(
     # clean up the generated query
     generated_query = clean_generated_query(generated_query)
 
-    # remove extra spaces around brackets especially for MySQL
-    generated_query = generated_query.replace(" ( ", "(").replace(" )", ")")
 
     if "logprobs" in r.json():
         logprobs = r.json()["logprobs"]

--- a/eval/api_runner.py
+++ b/eval/api_runner.py
@@ -13,6 +13,7 @@ from time import time
 import requests
 from utils.reporting import upload_results
 import sqlparse
+import re
 
 
 def clean_generated_query(query: str):
@@ -34,9 +35,8 @@ def clean_generated_query(query: str):
     query = query.replace("/ NULLIF (", "/ NULLIF (1.0 * ")
 
     # remove extra spaces around brackets especially for MySQL
-    query = query.replace(" ( ", "(").replace(" )", ")")
-    query = query.replace(" (", "(").replace(") ", ")")
-    query = query.replace("( ", "(").replace(" )", ")")
+    query = re.sub(r"\s*\(\s*", "(", query)  # Remove spaces before and after '('
+    query = re.sub(r"\s*\)", ")", query)  # Remove spaces before ')'
 
     return query
 


### PR DESCRIPTION
The eval I ran earlier had a lot of errors because of this space before  and after `(` and `)`.
This is something that is completely fine with postgres but erroneous in mysql. We do some post cleaning of the query to make sure we get rid of any such spaces. A case with spaces both before and after a bracket was handled but a more popular case is when there is a space after the bracket. Including this in the `clean_generated_query` for clarity.